### PR TITLE
#38 Clean up formatting and links on transport site

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,11 @@ All Endorsements start as _RESO Change Proposals (RCPs)_.
 
 Specifications use [semantic versioning](https://semver.org/).
 
-<br />
 
 # RCPs and Statuses
 * [**RATIFIED STANDARDS**](./proposals.md#ratified-standards)
 * [**DRAFT SPECIFICATIONS**](./proposals.md#draft-specifications)
 * [**IN PROGRESS PROPOSALS**](./proposals.md#in-progress-proposals)
-
-<br />
 
 # Current Change Proposals
 
@@ -31,22 +28,15 @@ Specifications use [semantic versioning](https://semver.org/).
 | [**RCP-041**](./proposals.md#payloads-20) | Payloads | 2.0 | IN PROGRESS | Apr 2022 |
 
 
-<br />
-
 # New Change Proposals
-
 Please see the section on [new change proposals](./reso-rcp-process.md#new-change-proposals) for an outline of the RCP process, or if you'd like to make a new change proposal.
-
-<br />
 
 # Certification and RESO Analytics
 More information about [RESO Certification](./certification-reso-analytics.md).
 
-<br />
-
 ---
 
-<br />
+[**About RESO**](https://reso.org)
 
-[[About RESO](https://reso.org)] &nbsp; [[RESO Data Dictionary](https://ddwiki.reso.org)]
+[**RESO Data Dictionary**](https://ddwiki.reso.org)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # RESO Endorsements
 _RESO Endorsements_ are modular specifications that are associated with a given transport protocol. 
 
-All Endorsements start as _RESO Change Proposals (RCPs)_. 
+All Endorsements start as [RESO Change Proposals (RCPs)](#reso-change-proposals). 
 
 Specifications use [semantic versioning](https://semver.org/).
 
@@ -19,17 +19,17 @@ Specifications use [semantic versioning](https://semver.org/).
 | [**RCP-037**](./proposals.md#web-api-core-200) | **Web API Core** | **2.0** | **RATIFIED** | **Jan 2021** |
 | [**RCP-038**](./proposals.md#payloads-17) | **Payloads (with IDX Payload)** | **1.7** | **RATIFIED** | **Aug 2021** |
 | |
-| [**RCP-010**](./proposals.md#web-api-addedit) | Web API Add/Edit | 2.0.0 | DRAFT | Apr 2017 |
-| [**RCP-019**](./proposals.md#web-api-validation-expressions) | Web API Validation Expressions | 2.0.0 | DRAFT | Apr 2018 |
-| [**RCP-032**](./proposals.md#lookup-resource) | Lookup Resource | 1.7 | DRAFT | Dec 2021 |
-| [**RCP-040**](./proposals.md#data-dictionary-20) | Data Dictionary | 2.0 | DRAFT | Dec 2021 |
+| [RCP-010](./proposals.md#web-api-addedit) | Web API Add/Edit | 2.0.0 | DRAFT | Apr 2017 |
+| [RCP-019](./proposals.md#web-api-validation-expressions) | Web API Validation Expressions | 2.0.0 | DRAFT | Apr 2018 |
+| [RCP-032](./proposals.md#lookup-resource) | Lookup Resource | 1.7 | DRAFT | Dec 2021 |
+| [RCP-040](./proposals.md#data-dictionary-20) | Data Dictionary | 2.0 | DRAFT | Dec 2021 |
 | |
-| [**RCP-039**](./proposals.md#web-api-core-210) | Web API Core | 2.1.0 | IN PROGRESS | Apr 2022 |
-| [**RCP-041**](./proposals.md#payloads-20) | Payloads | 2.0 | IN PROGRESS | Apr 2022 |
+| [RCP-039](./proposals.md#web-api-core-210) | Web API Core | 2.1.0 | IN PROGRESS | Apr 2022 |
+| [RCP-041](./proposals.md#payloads-20) | Payloads | 2.0 | IN PROGRESS | Apr 2022 |
 
 
-# New Change Proposals
-Please see the section on [new change proposals](./reso-rcp-process.md#new-change-proposals) for an outline of the RCP process, or if you'd like to make a new change proposal.
+# RESO Change Proposals
+Please see the section on [change proposals](./reso-rcp-process.md#reso-change-proposal-rcp-process) for an outline of the RCP process, or start a [new change proposal](./reso-rcp-process.md#new-change-proposals).
 
 # Certification and RESO Analytics
 More information about [RESO Certification](./certification-reso-analytics.md).

--- a/README.md
+++ b/README.md
@@ -1,228 +1,52 @@
 # RESO Endorsements
-Endorsements are modular specifications grouped by their transport procotol, for example, the _RESO Web API_. Specifications use [semantic versioning](https://semver.org/).
-* [**RATIFIED**](https://github.com/RESOStandards/reso-transport-specifications#ratified)
-* [**DRAFT**](https://github.com/RESOStandards/reso-transport-specifications#draft)
-* [**IN PROGRESS**](https://github.com/RESOStandards/reso-transport-specifications#in-progress)
+_RESO Endorsements_ are modular specifications that are associated with a given transport protocol. 
 
-Proposals MUST have two verified implementations from separate vendors before they can be adopted.
+All Endorsements start as _RESO Change Proposals (RCPs)_. 
 
-Please visit our [discussion forum](https://github.com/RESOStandards/reso-transport-specifications/discussions) if you have any questions or would like to start a proposal. See [issues](https://github.com/RESOStandards/reso-transport-specifications/issues) for new specifications.
+Specifications use [semantic versioning](https://semver.org/).
 
-## CHANGE PROPOSALS
+<br />
+
+# RCPs and Statuses
+* [**RATIFIED STANDARDS**](./proposals.md#ratified-standards)
+* [**DRAFT SPECIFICATIONS**](./proposals.md#draft-specifications)
+* [**IN PROGRESS PROPOSALS**](./proposals.md#in-progress-proposals)
+
+<br />
+
+# Current Change Proposals
 
 | RCP | Name | Version | Status | Status Date |
 | :-- | :-- | :-- | :-- | :-- |
-| [**RCP-036**](#data-dictionary-17) | Data Dictionary | 1.7 | [**RATIFIED**](https://github.com/RESOStandards/reso-transport-specifications#ratified) | Jan 2021 |
-| [**RCP-037**](#web-api-core-200) | Web API Core | 2.0 | [**RATIFIED**](https://github.com/RESOStandards/reso-transport-specifications#ratified) | Jan 2021|
-| [**RCP-038**](#payloads-17) | Payloads (with IDX Payload) | 1.7 | [**RATIFIED**](https://github.com/RESOStandards/reso-transport-specifications#ratified) | Aug 2021 |
-| [**RCP-010**](#web-api-addedit) | Web API Add/Edit | 2.0.0 | [**DRAFT**](https://github.com/RESOStandards/reso-transport-specifications#draft) | Apr 2017 |
-| [**RCP-019**](#web-api-validation-expressions) | Web API Validation Expressions | 2.0.0 | [**DRAFT**](https://github.com/RESOStandards/reso-transport-specifications#draft) | Apr 2018 |
-| [**RCP-032**](#lookup-resource) | Lookup Resource | 1.7 | [**DRAFT**](https://github.com/RESOStandards/reso-transport-specifications#draft) | Dec 2021 |
-| [**RCP-040**](#data-dictionary-20) | Data Dictionary | 2.0 | [**DRAFT**](https://github.com/RESOStandards/reso-transport-specifications#draft) | Dec 2021 |
-| [**RCP-039**](#web-api-core-210) | Web API Core | 2.1.0 | [**IN PROGRESS**](https://github.com/RESOStandards/reso-transport-specifications#in-progress) | Apr 2021 |
-| [**RCP-041**](#payloads-20) | Payloads | 2.0 | [**IN PROGRESS**](https://github.com/RESOStandards/reso-transport-specifications#in-progress) | Apr 2021 |
+| [**RCP-036**](./proposals.md#data-dictionary-17) | **Data Dictionary** | **1.7** | **RATIFIED** | **Jan 2021** |
+| [**RCP-037**](./proposals.md#web-api-core-200) | **Web API Core** | **2.0** | **RATIFIED** | **Jan 2021** |
+| [**RCP-038**](./proposals.md#payloads-17) | **Payloads (with IDX Payload)** | **1.7** | **RATIFIED** | **Aug 2021** |
+| |
+| [**RCP-010**](./proposals.md#web-api-addedit) | Web API Add/Edit | 2.0.0 | DRAFT | Apr 2017 |
+| [**RCP-019**](./proposals.md#web-api-validation-expressions) | Web API Validation Expressions | 2.0.0 | DRAFT | Apr 2018 |
+| [**RCP-032**](./proposals.md#lookup-resource) | Lookup Resource | 1.7 | DRAFT | Dec 2021 |
+| [**RCP-040**](./proposals.md#data-dictionary-20) | Data Dictionary | 2.0 | DRAFT | Dec 2021 |
+| |
+| [**RCP-039**](./proposals.md#web-api-core-210) | Web API Core | 2.1.0 | IN PROGRESS | Apr 2022 |
+| [**RCP-041**](./proposals.md#payloads-20) | Payloads | 2.0 | IN PROGRESS | Apr 2022 |
 
-<br />
-
----
-
-<br />
-
-# RATIFIED 
-Ratified proposals have been adopted by the workgroups and RESO as an organization. Proposals that require certification testing must have adopted a specification, testing rules, and production-ready testing tools for ratification.
-
-## [Data Dictionary 1.7](./data-dictionary.md)
-
-| **RCP** | RCP-036 |
-| :--- | :--- |
-| **Authors** | [Joshua Darnell](https://github.com/darnjo) ([RESO](mailto:josh@reso.org)) |
-| **Status** | **RATIFIED** |
-| **Date Ratified** | January 2021 |
-| **Dependencies** | [Web API Core 2.0.0+](./web-api-core.md) |
-| **Related Links** | [Specification](./data-dictionary.md)<br />[DD Wiki 1.7](https://ddwiki.reso.org/display/DDW17/RESO+Data+Dictionary+1.7)<br />[Data Dictionary Spreadsheet](https://docs.google.com/spreadsheets/d/1_59Iqr7AQ51rEFa7p0ND-YhJjEru8gY-D_HM1yy5c6w/edit?usp=sharing) |
-
-The Data Dictionary endorsement defines models for use in the RESO domain. These include Resources, Fields, Lookups, and Relationships between Resources.
-
-<br />
-
-## [Web API Core 2.0.0](./web-api-core.md)
-
-| **RCP** | RCP-037 |
-| :--- | :--- |
-| **Authors** | [Joshua Darnell](https://github.com/darnjo) ([RESO](mailto:josh@reso.org)) |
-| **Status** | **RATIFIED** |
-| **Date Ratified** | January 2021 |
-| **Protocol** | HTTP |
-| **Dependencies** | OData 4.0 or 4.01<br />TLS 1.2+<br />OAuth 2 (Auth Token or Client Credentials) |
-| **Related Links** | [Specification](./web-api-core.md)<br /> |
-
-The Web API Core endorsement defines the primary functionality RESO Web API servers are expected to support in order to provide both replication and live query support.
-
-<br />
-
-## [Payloads 1.7](./payloads.md)
-
-| **RCP** | RCP-038 |
-| :-- | :-- |
-| **Authors** | [Joshua Darnell](https://github.com/darnjo) ([RESO](mailto:josh@reso.org)) |
-| **Status** | **RATIFIED** |
-| **Date Ratified** | August 2021 |
-| **Protocol** | HTTP |
-| **Dependencies** | [Data Dictionary 1.7](data-dictionary.md)<br />[Web API Core 2.0.0+](./web-api-core.md) |
-| **Related Links** | [Specification](./payloads.md)<br /> |
-
-Defines general payloads data validation and availability testing rules, as well as the IDX Payload Endorsement.
-
-<br />
-
----
-
-<br />
-
-# DRAFT
-Draft proposals have been approved by the workgroups and organization and are awaiting implementations and community review.
-
-## [Web API Add/Edit](./web-api-add-edit.md)
-
-| **RCP** | RCP-010 |
-| :--- | :--- |
-| **Authors** | Sergio Del Rio ([T4Bi](Sergio.Del.Rio@t4bi.com))<br />[Joshua Darnell](https://github.com/darnjo) ([RESO](mailto:josh@reso.org)) |
-| **Status** | **DRAFT** |
-| **Date Approved** | April 2017 (original) |
-| **Dependencies** | [Data Dictionary 1.7+](./data-dictionary.md)<br />[Web API 2.0.0+](./web-api-core.md) |
-| **Related Links** | [Specification (Draft PR)](https://github.com/RESOStandards/reso-transport-specifications/blob/c94fcd4d511a70f500a462cd10b8e48e10d0c113/data-dictionary.md)<br />[DD Wiki 1.7](https://ddwiki.reso.org/display/DDW17/RESO+Data+Dictionary+1.7)<br />[Data Dictionary Spreadsheet](https://docs.google.com/spreadsheets/d/1_59Iqr7AQ51rEFa7p0ND-YhJjEru8gY-D_HM1yy5c6w/edit?usp=sharing)<br /> |
-
-The Web API Add/Edit endorsement defines how to Create, Update, and Delete data in the RESO Web API. 
-
-<br />
-
-## [Web API Validation Expressions](./web-api-validation-expression.md)
-
-| **RCP** | RCP-019 |
-| :--- | :--- |
-| **Authors** | [Joshua Darnell](https://github.com/darnjo) ([RESO](mailto:josh@reso.org))<br />Paul Stusiak ([Falcon Technologies](mailto:pstusiak@falcontechnologies.com)) |
-| **Status** | **DRAFT** |
-| **Date Approved** | April 2018 |
-| **Dependencies** | [Data Dictionary 1.7+](./data-dictionary.md)<br />[Web API 2.0.0+](./web-api-core.md)<br />[Validation Expression grammar](https://github.com/darnjo/rcp019) |
-| **Related Links** | [Specification (Draft PR)](https://github.com/RESOStandards/reso-transport-specifications/blob/c94fcd4d511a70f500a462cd10b8e48e10d0c113/data-dictionary.md)<br />[DD Wiki 1.7](https://ddwiki.reso.org/display/DDW17/RESO+Data+Dictionary+1.7)<br />[Data Dictionary Spreadsheet](https://docs.google.com/spreadsheets/d/1_59Iqr7AQ51rEFa7p0ND-YhJjEru8gY-D_HM1yy5c6w/edit?usp=sharing)<br /> |
-
-Web API Validation Expressions allow for the transport of machine-executable business rules using the [RETS 019 Validation Expression grammar](https://github.com/darnjo/rcp019).
-
-<br />
-
-## [Lookup Resource](https://github.com/RESOStandards/reso-transport-specifications/blob/c94fcd4d511a70f500a462cd10b8e48e10d0c113/data-dictionary.md)
-
-| **RCP** | RCP-032 |
-| :--- | :--- |
-| **Authors** | [Joshua Darnell](https://github.com/darnjo) ([RESO](mailto:josh@reso.org))<br />Ryan Yates ([Rapattoni Corporation](mailto:ryates@rapattoni.com))<br />Sergio Del Rio ([T4Bi](Sergio.Del.Rio@t4bi.com))<br />Rob Larson ([Larson Consulting](rob@larson.cc))<br />Paul Stusiak ([Falcon Technologies](mailto:pstusiak@falcontechnologies.com)) |
-| **Status** | **DRAFT** |
-| **Status Date** | December 2021 |
-| **Dependencies** | [Web API Core 2.0.0+](./web-api-core.md) |
-| **Related Links** | [Specification (Draft PR)](https://github.com/RESOStandards/reso-transport-specifications/blob/c94fcd4d511a70f500a462cd10b8e48e10d0c113/data-dictionary.md)<br />[DD Wiki 1.7](https://ddwiki.reso.org/display/DDW17/RESO+Data+Dictionary+1.7)<br />[Data Dictionary Spreadsheet](https://docs.google.com/spreadsheets/d/1_59Iqr7AQ51rEFa7p0ND-YhJjEru8gY-D_HM1yy5c6w/edit?usp=sharing) |
-
-The Lookup Resource provides a framework to advertise human-friendly display names and use them in payloads. This reduces the amount of interpretation data consumers need to do when using enumerations, and they can display what they get in the payload directly rather than inferring the values from annotations. It also better supports providers who have a large amount of lookup metadata, allowing it to be consumed and updated through incremental updates rather than having to update all metadata each time something changes.
-
-<br />
-
-## [Data Dictionary 2.0](https://github.com/RESOStandards/reso-transport-specifications/blob/c1baab163567a98c5457137d65ad09e3a22ac46e/data-dictionary.md)
-
-| **RCP** | RCP-040 |
-| :--- | :--- |
-| **Authors** | [Joshua Darnell](https://github.com/darnjo) ([RESO](mailto:josh@reso.org)) |
-| **Status** | **DRAFT** |
-| **Dependencies** | [Web API Core 2.0.0+](./web-api-core.md) |
-| **Related Links** | [Specification (Draft PR)](https://github.com/RESOStandards/reso-transport-specifications/blob/c1baab163567a98c5457137d65ad09e3a22ac46e/data-dictionary.md)<br />[DD Wiki 1.7](https://ddwiki.reso.org/display/DDW17/RESO+Data+Dictionary+1.7)<br />[Data Dictionary Spreadsheet](https://docs.google.com/spreadsheets/d/1_59Iqr7AQ51rEFa7p0ND-YhJjEru8gY-D_HM1yy5c6w/edit?usp=sharing) |
-
-The Data Dictionary endorsement defines models for use in the RESO domain. These include Resources, Fields, Lookups, and Relationships between Resources.
-
-**New in version 2.0**
-* Added new resources, fields, and enumerations
-* Additional validation of resources, fields, and enumerations using a number of heuristics (substring, edit distance, and data-driven matching)
-* Data validation against server metadata - if items are found in the payload that are not advertised, providers will ont pass testing
-* Updated Data Dictionary reference sheet structure
-
-<br />
-
----
-
-<br />
-
-# IN PROGRESS
-Proposals that are in progress are ones that have been reviewed by the workgroups and are actively being worked on prior to draft status.
-
-## [Web API Core 2.1.0](https://github.com/RESOStandards/reso-transport-specifications/issues/22)
-
-| **RCP** | RCP-039 |
-| :--- | :--- |
-| **Authors** | [Joshua Darnell](https://github.com/darnjo) ([RESO](mailto:josh@reso.org)) |
-| **Status** | **IN PROGRESS** |
-| **Date Started** | April 2022 |
-| **Protocol** | HTTP |
-| **Dependencies** | OData 4.0 or 4.01<br />TLS 1.2+<br />OAuth 2 (Auth Token or Client Credentials) |
-| **Related Links** | [GitHub Issue](https://github.com/RESOStandards/reso-transport-specifications/issues/22)<br /> |
-
-The Web API Core 2.1.0 endorsement defines the primary functionality RESO Web API servers are expected to have in order to provide both replication and live query support. 
-
-**New in version 2.1.0**
-* Support for OData `$expand`
-* Server-Driven Paging (`@odata.nextLink`) required for Certification
-* Support for the Lookup Resource, including string comparison tests for enumerations
-
-<br />
-
-## [Payloads 2.0](https://github.com/RESOStandards/reso-transport-specifications/issues/23)
-
-| **RCP** | RCP-041 |
-| :-- | :-- |
-| **Authors** | [Joshua Darnell](https://github.com/darnjo) ([RESO](mailto:josh@reso.org)) |
-| **Status** | **IN PROGRESS** |
-| **Date Started** | April 2022 |
-| **Protocol** | HTTP |
-| **Dependencies** | [Data Dictionary 1.7](./data-dictionary.md)<br />[Web API Core 2.0.0+](./web-api-core.md) |
-| **Related Links** | [GitHub Issue](https://github.com/RESOStandards/reso-transport-specifications/issues/23)<br /> |
-
-Payloads 2.0 defines general data validation and availability testing rules, as well as the IDX Payload Endorsement.
-
-**New in version 2.0**
-* Support for OData `$expand`
-* Sampling using server-driven paging
-* Strict checking of what's advertised in the metadata vs. what was found in the payload
-
-<br /><br />
-
-
-# Related Documents
-The following documents may also be helpful:
-* [RESO DDWiki](https://ddwiki.reso.org/display/DDW17/)
-* [RESO Data Dictionary 1.7 Reference Spreadsheet](https://docs.google.com/spreadsheets/d/1_59Iqr7AQ51rEFa7p0ND-YhJjEru8gY-D_HM1yy5c6w/edit?usp=sharing)
-* [RESO Commander](https://github.com/RESOStandards/web-api-commander)
 
 <br />
 
 # New Change Proposals
 
-## RCP Template
-If you would like to suggest a new change proposal, please use the [**RCP Template**](./rcp-template.md) in this repository and fill in each section accordingly. 
+Please see the section on [new change proposals](./reso-rcp-process.md#new-change-proposals) for an outline of the RCP process, or if you'd like to make a new change proposal.
 
-## Submission Process
+<br />
 
-## 1. Proposal Phase
-* Post on GitHub Discussions. 
-* Request that the topic be added to the appropriate Transport and/or Certification agendas. Ideally, there would be some activity in the GitHub discussion before and after the workgroup meeting. 
-* Once there’s consensus in the group to move a given item forward, an issue should be created and work on a specification can begin. 
-* A preliminary specification and set of testing rules should be produced that others could (unambiguously) build software to. An impact assessment should also be included, when applicable.
-* After work on the specification is complete, it should be posted for community review at least two weeks before the Transport or Certification meeting it’s to be discussed in.
+# Certification and RESO Analytics
+More information about [RESO Certification](./certification-reso-analytics.md).
 
-## 2. Draft Phase
-* Once approved into draft status, a draft PR should be made.
-* The proposal will stay in draft status until it has at least two implementations from two separate vendors, at which point there will be a workgroup discussion, including revisiting which existing specifications and versions to add it to, if applicable. 
-* The implementations should be verified against the proposed testing rules by RESO staff, even if on a development server. 
+<br />
 
-## 3. Approval and Adoption Phase
-* The PR will be taken out of draft status at this point, awaiting final approval.
-* There may also be a motion to create Certification tools, and potentially new reports or metrics, at that time. If so, these items need to be added to RESO’s backlog. 
-* The Transport and Certification groups will decide which specification(s) it should be added to and which version(s) to target; those writing the proposals can make requests in this regard. 
-* Once the new specification is ready for ratification, related PRs will be merged into their corresponding specifications.
+---
 
+<br />
 
-Please contact [RESO Development](mailto:dev@reso.org) if you have any questions.
+[[About RESO](https://reso.org)] &nbsp; [[RESO Data Dictionary](https://ddwiki.reso.org)]
+

--- a/certification-reso-analytics.md
+++ b/certification-reso-analytics.md
@@ -1,0 +1,26 @@
+# Certification
+Providers are expected to complete self-testing with the [RESO Commander](https://commander.reso.org) prior to certification. See the section on [RESO Certification](https://commander.reso.org/#reso-certification).
+
+Self-Certification UI and API coming in November 2022!
+
+<br /><br />
+
+# RESO Analytics
+RESO Analytics is a new way of looking at standardization. It allows the community and RESO as an organization better understand what's being used in practice. 
+
+Goals
+* Allow data consumers to find standard data sets across markets and different providers.
+* Help providers improve the standardization rates and responsiveness of their servers through objective, automated testing.
+* Create industry aggregates to show usage and adoption metrics.
+
+<br />
+
+For more information, visit: https://reso.org/certification
+
+---
+
+<br />
+
+[<- HOME](./README.md)
+
+

--- a/proposals.md
+++ b/proposals.md
@@ -1,25 +1,19 @@
 # RESO Change Proposals (RCPs)
 RESO Change Proposals are created through a [community review process](./reso-rcp-process.md).
 
-See [new change proposals](./reso-rcp-process.md#new-change-proposals) 
-
-
-<br /><br />
-
+See the section on [change proposals](./reso-rcp-process.md#change-proposals) for more information.
 
 # RCPs and Statuses
 * [**RATIFIED STANDARDS**](./proposals#ratified-standards)
 * [**DRAFT SPECIFICATIONS**](./proposals#draft-specifications)
 * [**IN PROGRESS PROPOSALS**](./proposals#in-progress-proposals)
 
-<br /><br />
+---
 
 # RATIFIED STANDARDS
 Ratified standards have been adopted by the Transport Workgroup and RESO as an organization.
 
 Proposals that require certification must have adopted a specification, testing rules, and production-ready testing tools before being ratified.
-
-<br />
 
 ## Data Dictionary 1.7
 
@@ -34,7 +28,7 @@ Proposals that require certification must have adopted a specification, testing 
 
 The Data Dictionary endorsement defines models for use in the RESO domain. These include Resources, Fields, Lookups, and Relationships between Resources. The Data Dictionary may use the RESO Web API or RESO's Common Schema JSON format for transport.
 
-<br /><br />
+<br />
 
 ## Web API Core 2.0.0
 
@@ -50,7 +44,7 @@ The Data Dictionary endorsement defines models for use in the RESO domain. These
 
 The Web API Core endorsement defines the primary functionality RESO Web API servers are expected to support in order to provide both replication and live query support.
 
-<br /><br />
+<br />
 
 ## Payloads 1.7
 
@@ -65,16 +59,10 @@ The Web API Core endorsement defines the primary functionality RESO Web API serv
 
 Defines general payloads data validation and availability testing rules, as well as the IDX Payload Endorsement.
 
-<br /><br />
-
 ---
-
-<br /><br />
 
 # DRAFT SPECIFICATIONS
 Draft specifications have been approved by the Certification Subgroup and are awaiting implementations and community review prior to Transport approval.
-
-<br />
 
 ## Web API Add/Edit
 
@@ -89,14 +77,14 @@ Draft specifications have been approved by the Certification Subgroup and are aw
 
 The Web API Add/Edit endorsement defines how to Create, Update, and Delete data in the RESO Web API. 
 
-<br /><br />
+<br />
 
 ## Web API Validation Expressions
 
 | **RCP** | RCP-019 |
 | :--- | :--- |
 | **Authors** | [Joshua Darnell](https://github.com/darnjo) ([RESO](mailto:josh@reso.org))<br />Paul Stusiak ([Falcon Technologies](mailto:pstusiak@falcontechnologies.com)) |
-| **Specification** | [LINK TO RCP](./web-api-validation-expression.md) |
+| **Specification** | [**LINK TO RCP**](./web-api-validation-expression.md) |
 | **Status** | **DRAFT** |
 | **Date Approved** | April 2018 |
 | **Dependencies** | [Validation Expression grammar](https://github.com/darnjo/rcp019) <br /> [Data Dictionary 1.7+](./data-dictionary.md)<br />[Web API 2.0.0+](./web-api-core.md)<br /> |
@@ -104,7 +92,7 @@ The Web API Add/Edit endorsement defines how to Create, Update, and Delete data 
 
 Web API Validation Expressions allow for the transport of machine-executable business rules using the [RETS 019 Validation Expression grammar](https://github.com/darnjo/rcp019).
 
-<br /><br />
+<br />
 
 ## Lookup Resource
 
@@ -119,7 +107,7 @@ Web API Validation Expressions allow for the transport of machine-executable bus
 
 The Lookup Resource provides a framework to advertise human-friendly display names and use them in payloads. This reduces the amount of interpretation data consumers need to do when using enumerations, and they can display what they get in the payload directly rather than inferring the values from annotations. It also better supports providers who have a large amount of lookup metadata, allowing it to be consumed and updated through incremental updates rather than having to update all metadata each time something changes.
 
-<br /><br />
+<br />
 
 ## Data Dictionary 2.0
 
@@ -140,16 +128,10 @@ The Data Dictionary endorsement defines models for use in the RESO domain. These
 * Data validation against server metadata - if items are found in the payload that are not advertised, providers will ont pass testing
 * Updated Data Dictionary reference sheet structure
 
-<br /><br />
-
 ---
-
-<br /><br />
 
 # IN PROGRESS PROPOSALS
 In progress proposals are ones that are in review by Transport and Certification. See the [RESO RCP Process](./reso-rcp-process.md) and section on [new change proposals](./reso-rcp-process.md#new-change-proposals).
-
-<br />
 
 ## Web API Core 2.1.0
 
@@ -169,7 +151,7 @@ The Web API Core 2.1.0 endorsement defines the primary functionality RESO Web AP
 * Server-Driven Paging (`@odata.nextLink`) required for Certification
 * Support for the Lookup Resource, including string comparison tests for enumerations
 
-<br /><br />
+<br />
 
 ## Payloads 2.0
 
@@ -195,6 +177,4 @@ Please contact dev@reso.org if you have any questions.
 
 ---
 
-<br />
-
-[<- HOME](./README.md)
+[**<- HOME**](./README.md)

--- a/proposals.md
+++ b/proposals.md
@@ -1,0 +1,200 @@
+# RESO Change Proposals (RCPs)
+RESO Change Proposals are created through a [community review process](./reso-rcp-process.md).
+
+See [new change proposals](./reso-rcp-process.md#new-change-proposals) 
+
+
+<br /><br />
+
+
+# RCPs and Statuses
+* [**RATIFIED STANDARDS**](./proposals#ratified-standards)
+* [**DRAFT SPECIFICATIONS**](./proposals#draft-specifications)
+* [**IN PROGRESS PROPOSALS**](./proposals#in-progress-proposals)
+
+<br /><br />
+
+# RATIFIED STANDARDS
+Ratified standards have been adopted by the Transport Workgroup and RESO as an organization.
+
+Proposals that require certification must have adopted a specification, testing rules, and production-ready testing tools before being ratified.
+
+<br />
+
+## Data Dictionary 1.7
+
+| **RCP** | RCP-036 |
+| :--- | :--- |
+| **Authors** | [Joshua Darnell](https://github.com/darnjo) ([RESO](mailto:josh@reso.org)) |
+| **Specification** | [**LINK TO RCP**](./data-dictionary.md) |
+| **Status** | **RATIFIED** |
+| **Date Ratified** | January 2021 |
+| **Dependencies** | [Web API Core 2.0.0+](./web-api-core.md) |
+| **Related Links** | [DD Wiki 1.7](https://ddwiki.reso.org/display/DDW17/RESO+Data+Dictionary+1.7)<br />[Data Dictionary 1.7 Spreadsheet](https://docs.google.com/spreadsheets/d/1_59Iqr7AQ51rEFa7p0ND-YhJjEru8gY-D_HM1yy5c6w/edit?usp=sharing) |
+
+The Data Dictionary endorsement defines models for use in the RESO domain. These include Resources, Fields, Lookups, and Relationships between Resources. The Data Dictionary may use the RESO Web API or RESO's Common Schema JSON format for transport.
+
+<br /><br />
+
+## Web API Core 2.0.0
+
+| **RCP** | RCP-037 |
+| :--- | :--- |
+| **Authors** | [Joshua Darnell](https://github.com/darnjo) ([RESO](mailto:josh@reso.org))  |
+| **Specification** | [**LINK TO RCP**](./web-api-core.md) |
+| **Status** | **RATIFIED** |
+| **Date Ratified** | January 2021 |
+| **Protocol** | HTTP |
+| **Dependencies** | OData 4.0 or 4.01<br />TLS 1.2+<br />OAuth 2 (Auth Token or Client Credentials) |
+| **Related Links** | [OASIS OData TC](https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=odata) <br /> |
+
+The Web API Core endorsement defines the primary functionality RESO Web API servers are expected to support in order to provide both replication and live query support.
+
+<br /><br />
+
+## Payloads 1.7
+
+| **RCP** | RCP-038 |
+| :-- | :-- |
+| **Authors** | [Joshua Darnell](https://github.com/darnjo) ([RESO](mailto:josh@reso.org)) |
+| **Specification** | [**LINK TO RCP**](./payloads.md) |
+| **Status** | **RATIFIED** |
+| **Date Ratified** | August 2021 |
+| **Protocol** | HTTP |
+| **Dependencies** | [Data Dictionary 1.7](data-dictionary.md)<br />[Web API Core 2.0.0+](./web-api-core.md) |
+
+Defines general payloads data validation and availability testing rules, as well as the IDX Payload Endorsement.
+
+<br /><br />
+
+---
+
+<br /><br />
+
+# DRAFT SPECIFICATIONS
+Draft specifications have been approved by the Certification Subgroup and are awaiting implementations and community review prior to Transport approval.
+
+<br />
+
+## Web API Add/Edit
+
+| **RCP** | RCP-010 |
+| :--- | :--- |
+| **Authors** | Sergio Del Rio ([T4Bi](Sergio.Del.Rio@t4bi.com))<br />[Joshua Darnell](https://github.com/darnjo) ([RESO](mailto:josh@reso.org)) |
+| **Specification** | [**LINK TO RCP**](./web-api-add-edit.md) |
+| **Status** | **DRAFT** |
+| **Date Approved** | April 2017 (original) |
+| **Dependencies** | [Data Dictionary 1.7+](./data-dictionary.md)<br />[Web API 2.0.0+](./web-api-core.md) |
+| **Related Links** | [Draft Testing Rules](https://github.com/RESOStandards/web-api-commander/discussions/64)<br />[DD Wiki 1.7](https://ddwiki.reso.org/display/DDW17/RESO+Data+Dictionary+1.7)<br />[Data Dictionary Spreadsheet](https://docs.google.com/spreadsheets/d/1_59Iqr7AQ51rEFa7p0ND-YhJjEru8gY-D_HM1yy5c6w/edit?usp=sharing)<br /> |
+
+The Web API Add/Edit endorsement defines how to Create, Update, and Delete data in the RESO Web API. 
+
+<br /><br />
+
+## Web API Validation Expressions
+
+| **RCP** | RCP-019 |
+| :--- | :--- |
+| **Authors** | [Joshua Darnell](https://github.com/darnjo) ([RESO](mailto:josh@reso.org))<br />Paul Stusiak ([Falcon Technologies](mailto:pstusiak@falcontechnologies.com)) |
+| **Specification** | [LINK TO RCP](./web-api-validation-expression.md) |
+| **Status** | **DRAFT** |
+| **Date Approved** | April 2018 |
+| **Dependencies** | [Validation Expression grammar](https://github.com/darnjo/rcp019) <br /> [Data Dictionary 1.7+](./data-dictionary.md)<br />[Web API 2.0.0+](./web-api-core.md)<br /> |
+| **Related Links** | [DD Wiki 1.7](https://ddwiki.reso.org/display/DDW17/RESO+Data+Dictionary+1.7)<br />[Data Dictionary Spreadsheet](https://docs.google.com/spreadsheets/d/1_59Iqr7AQ51rEFa7p0ND-YhJjEru8gY-D_HM1yy5c6w/edit?usp=sharing)<br /> |
+
+Web API Validation Expressions allow for the transport of machine-executable business rules using the [RETS 019 Validation Expression grammar](https://github.com/darnjo/rcp019).
+
+<br /><br />
+
+## Lookup Resource
+
+| **RCP** | RCP-032 |
+| :--- | :--- |
+| **Authors** | [Joshua Darnell](https://github.com/darnjo) ([RESO](mailto:josh@reso.org))<br />Ryan Yates ([Rapattoni Corporation](mailto:ryates@rapattoni.com))<br />Sergio Del Rio ([T4Bi](Sergio.Del.Rio@t4bi.com))<br />Rob Larson ([Larson Consulting](rob@larson.cc))<br />Paul Stusiak ([Falcon Technologies](mailto:pstusiak@falcontechnologies.com)) |
+| **Specification** | [**LINK TO RCP**](https://github.com/RESOStandards/transport/blob/c94fcd4d511a70f500a462cd10b8e48e10d0c113/data-dictionary.md) |
+| **Status** | **DRAFT** |
+| **Status Date** | December 2021 |
+| **Dependencies** | [Data Dictionary 1.7+](./data-dictionary.md)<br />[Web API Core 2.0.0+](./web-api-core.md) |
+| **Related Links** | [DD Wiki 1.7](https://ddwiki.reso.org/display/DDW17/RESO+Data+Dictionary+1.7)<br />[Data Dictionary Spreadsheet](https://docs.google.com/spreadsheets/d/1_59Iqr7AQ51rEFa7p0ND-YhJjEru8gY-D_HM1yy5c6w/edit?usp=sharing) |
+
+The Lookup Resource provides a framework to advertise human-friendly display names and use them in payloads. This reduces the amount of interpretation data consumers need to do when using enumerations, and they can display what they get in the payload directly rather than inferring the values from annotations. It also better supports providers who have a large amount of lookup metadata, allowing it to be consumed and updated through incremental updates rather than having to update all metadata each time something changes.
+
+<br /><br />
+
+## Data Dictionary 2.0
+
+| **RCP** | RCP-040 |
+| :--- | :--- |
+| **Authors** | [Joshua Darnell](https://github.com/darnjo) ([RESO](mailto:josh@reso.org)) |
+| **Specification** | [**LINK TO RCP**](https://github.com/RESOStandards/transport/blob/c1baab163567a98c5457137d65ad09e3a22ac46e/data-dictionary.md) |
+| **Status** | **DRAFT** |
+| **Date Approved** | Sept 2022 |
+| **Dependencies** | [Web API Core 2.0.0+](./web-api-core.md) |
+| **Related Links** | [DD Wiki 2.0](https://ddwiki.reso.org/pages/viewpage.action?pageId=1123655)<br />[Data Dictionary 2.0 Spreadsheet](https://docs.google.com/spreadsheets/d/1_59Iqr7AQ51rEFa7p0ND-YhJjEru8gY-D_HM1yy5c6w/edit?usp=sharing) |
+
+The Data Dictionary endorsement defines models for use in the RESO domain. These include Resources, Fields, Lookups, and Relationships between Resources.
+
+**New in version 2.0**
+* Added new resources, fields, and enumerations
+* Additional validation of resources, fields, and enumerations using a number of heuristics (substring, edit distance, and data-driven matching)
+* Data validation against server metadata - if items are found in the payload that are not advertised, providers will ont pass testing
+* Updated Data Dictionary reference sheet structure
+
+<br /><br />
+
+---
+
+<br /><br />
+
+# IN PROGRESS PROPOSALS
+In progress proposals are ones that are in review by Transport and Certification. See the [RESO RCP Process](./reso-rcp-process.md) and section on [new change proposals](./reso-rcp-process.md#new-change-proposals).
+
+<br />
+
+## Web API Core 2.1.0
+
+| **RCP** | RCP-039 |
+| :--- | :--- |
+| **Authors** | [Joshua Darnell](https://github.com/darnjo) ([RESO](mailto:josh@reso.org)) |
+| **Specification** | [**LINK TO TESTING RULES**](https://github.com/RESOStandards/transport/issues/22) |
+| **Status** | **IN PROGRESS** |
+| **Date Proposed** | April 2022 |
+| **Protocol** | HTTP |
+| **Dependencies** | OData 4.0 or 4.01<br />TLS 1.2+<br />OAuth 2 (Auth Token or Client Credentials) |
+
+The Web API Core 2.1.0 endorsement defines the primary functionality RESO Web API servers are expected to have in order to provide both replication and live query support. 
+
+**New in version 2.1.0**
+* Support for OData `$expand`
+* Server-Driven Paging (`@odata.nextLink`) required for Certification
+* Support for the Lookup Resource, including string comparison tests for enumerations
+
+<br /><br />
+
+## Payloads 2.0
+
+| **RCP** | RCP-041 |
+| :-- | :-- |
+| **Authors** | [Joshua Darnell](https://github.com/darnjo) ([RESO](mailto:josh@reso.org)) |
+| **Specification** | [**LINK TO TESTING RULES**](https://github.com/RESOStandards/reso-transport-specifications/issues/23) |
+| **Status** | **IN PROGRESS** |
+| **Date Started** | April 2022 |
+| **Protocol** | HTTP |
+| **Dependencies** | [Data Dictionary 1.7](./data-dictionary.md)<br />[Web API Core 2.0.0+](./web-api-core.md) |
+
+Payloads 2.0 defines general data validation and availability testing rules, as well as the IDX Payload Endorsement.
+
+**New in version 2.0**
+* Support for OData `$expand`
+* Sampling using server-driven paging
+* Strict checking of what's advertised in the metadata vs. what was found in the payload
+
+<br />
+
+Please contact dev@reso.org if you have any questions.
+
+---
+
+<br />
+
+[<- HOME](./README.md)

--- a/rcp-template.md
+++ b/rcp-template.md
@@ -1,13 +1,14 @@
 # RESO (Endorsement Name) Endorsement
 
-| **Version** | x.y.z |
+| **RCP** | RCP-XXX |
 | :--- | :--- |
-| **Submitter** | [Name of Author](mailto:your@company.com) |
-| **Co-Submitter** | [Name of Author](mailto:your@company.com) |
-| **Written** | June 2020 |
-| **Ratified** | December 2020 |
-| **RCP** | RCP-XYZ |
-| **Related RCPs** | [Related RCP](https://transport.reso.org) |
+| **Authors** | [Author 1](#)<br />[Author 2](#) |
+| **Specification** | [**LINK TO RCP**](#) |
+| **Status** | IN PROGRESS |
+| **Date Ratified** | Month YYYY |
+| **Dependencies** | [Link 1](#)<br />[Link 2](#) |
+| **Related Links** | [Link 1](#)<br />[Link 2](#) |
+
 
 <br /><br />
 
@@ -53,7 +54,7 @@ Provide specifics about the proposal in this section.
 The following should be included:
 * Information about Authorization or Authentication, when relevant. 
 * Sample request and response payloads.
-* Examples of algorithms written in pseudocode.
+* Examples of algorithms written in pseudo code.
 * Links to existing specifications used in the standard, with examples of how they're used.
 
 <br /><br />

--- a/reso-rcp-process.md
+++ b/reso-rcp-process.md
@@ -1,7 +1,7 @@
-# New Change Proposals
-The RESO RCP Process has the following phases:
+# RESO Change Proposal (RCP) Process
+The RCP Process is as follows:
 
-## Change Proposals
+## New Change Proposals
 1. Make a post on [GitHub Discussions](https://github.com/RESOStandards/transport/discussions). This should contain a summary of the business case, list of requirements, and initial proposal.
 2. Request that the topic be added to the Transport Workgroup agenda by emailing transport@reso.org at least two weeks before the meeting in which it's to be discussed. Ideally, there should be activity in the GitHub Discussion prior to the workgroup meeting. 
 3. Once there’s consensus in the group to move a given item forward, Transport will send it to the Certification Subgroup. [An issue should be created](https://github.com/RESOStandards/transport/issues/new) with a preliminary set of testing rules that could be used to (unambiguously) build software with. An impact assessment should also be included, when applicable.

--- a/reso-rcp-process.md
+++ b/reso-rcp-process.md
@@ -1,0 +1,33 @@
+# New Change Proposals
+The RESO RCP Process has the following phases:
+
+## Change Proposals
+1. Make a post on [GitHub Discussions](https://github.com/RESOStandards/transport/discussions). This should contain a summary of the business case, list of requirements, and initial proposal.
+2. Request that the topic be added to the Transport Workgroup agenda by emailing transport@reso.org at least two weeks before the meeting in which it's to be discussed. Ideally, there should be activity in the GitHub Discussion prior to the workgroup meeting. 
+3. Once there’s consensus in the group to move a given item forward, Transport will send it to the Certification Subgroup. [An issue should be created](https://github.com/RESOStandards/transport/issues/new) with a preliminary set of testing rules that could be used to (unambiguously) build software with. An impact assessment should also be included, when applicable.
+4. Proposed testing rules will be reviewed by the Certification Subgroup.
+5. Once approved, a draft specification should be created. Please use the [RCP Template](./rcp-template.md). If the change proposal is based on an existing RCP, please create a new branch from the existing proposal. Otherwise, create a new branch.
+
+## Draft Specification and Testing Rules
+1. The Certification Subgroup will review the draft specification. Once approved, a draft PR will be made.
+2. The proposal will stay in draft status until it has at least two implementations from two separate vendors.
+3. Implementations must be verified against the proposed testing rules by RESO staff, even if on a development server. Contact dev@reso.org for verification.
+4. Once implementations have been verified, the proposal will be approved by the Certification Subgroup and sent to Transport for final approval. Keep in mind that additional changes may be requested by the community before proceeding.
+
+## Approval and Adoption Phase
+1. At this point, the RCP is ready for approval by the Transport Workgroup. If the change proposal is based on an existing specification, Transport will decide which version of the specification the changes will apply to.
+2. There may also be a motion to create certification tools and potentially new reports or metrics. These items will be added to RESO's backlog, once approved.
+3. A motion and second will be made to adopt the specification. 
+4. If testing tools are to be created, that work must be complete before ratification. 
+5. The proposal will be sent to the RESO Board of Directors to be ratified.
+
+
+<br />
+
+Please contact dev@reso.org if you have any questions.
+
+---
+<br />
+
+[<- Home](./README.md)
+

--- a/reso-rcp-process.md
+++ b/reso-rcp-process.md
@@ -26,8 +26,7 @@ The RESO RCP Process has the following phases:
 
 Please contact dev@reso.org if you have any questions.
 
----
-<br />
+------
 
-[<- Home](./README.md)
+[**<- HOME**](./README.md)
 

--- a/web-api-validation-expression.md
+++ b/web-api-validation-expression.md
@@ -1,1 +1,87 @@
-[Current RCP-019 Proposal](https://github.com/RESOStandards/reso-transport-specifications/files/8384860/RESOWebAPIRCP-RCP-WEBAPI-019ValidationExpressionintheWebAPI-300322-2353.pdf)
+# [RCP-019] RESO Web API Validation Expressions
+RESO Validation Expressions build on the RETS Validation Expression grammar to provide a familiar, intermediate representation of computable business rules. The RCP-019 proposal consists of a Rules resource for transport and a grammar. 
+
+[**RCP-019 Proposal in PDF format**](https://github.com/RESOStandards/reso-transport-specifications/files/8384860/RESOWebAPIRCP-RCP-WEBAPI-019ValidationExpressionintheWebAPI-300322-2353.pdf)
+
+
+# Rules Resource
+The [Rules Resource](https://ddwiki.reso.org/display/DDW17/Rules+Resource) has been added to Data Dictionary 1.7+ to provide a transport mechanism.
+
+
+# Rules Grammar
+The RESO Validation Expression grammar assumes that rules are ordered sequentially, and will be process in order when dependencies require it. Not all rules are dependent on each other. Both independent and dependent rules can be parallelized, but care must be taken in the latter case to avoid data hazards (out of order operations).
+
+The Validation Expression grammar is not Turing complete by default. It requires the use of custom functions to iterate or recurse over a potentially unbounded collection of items. In other words, rule sets are always guaranteed to terminate. This is a good thing.
+
+Some examples from the current [RCP-019 grammar](https://github.com/darnjo/rcp019), which uses the [ANTLR4 Format](https://www.antlr.org/):
+
+### Basic Examples
+
+### Arithmetic Operators
+`3 + 5`
+
+`1 * 3 + 2 - 5`
+
+### Bracketed RETSNAMEs  
+`[ListPrice] > 0`
+
+### RCP61 added support for unbracketed RETSNAMEs. This also works for DICTNAMEs.
+`ListPrice > 0`
+
+### To get current value of any field, just use the `DICTNAME` of that field  
+`ListPrice`
+
+### Access the last value of a field
+
+`LAST Status != "Sold"`
+
+### Field change detection
+`ListPrice != LAST ListPrice`
+
+### Function calls are also supported
+`foo()`  
+`foo ('bar', 'baz', 42)`
+
+_Cannot use any RETSNAMEs, DICTNAMEs, or reserved words_
+
+### Lists of expressions
+`(ListPrice, Status, 3+5, LAST Status, (1, 2, 3))`
+
+### Supports complex expressions with grouping  
+`ListPrice > 5.01 .AND. (1, 2, 3) .CONTAINS. 3 .OR. (Status .IN. ('Active', 'Pending') .AND. .USERLEVEL. != "Admin")`
+
+### Which parses differently than  
+`ListPrice > 5.01 .AND. (1, 2, 3) .CONTAINS. 3 .OR. Status .IN. ('Active', 'Pending') .AND. .USERLEVEL. != "Admin"`
+    
+<br />
+
+## Collection Support
+RCP-019.1 added support for collections, which include `LIST()` and `SET()`. 
+
+These functions take 0 or more items.
+
+Backwards compatibility with the previous list syntax of `()` in RCP-019 has been preserved.
+
+| Expression  | Result |  Comments |
+| :--- | :--- | :--- |
+|`LIST(1, 2, 2, 3)`|`LIST(1, 2, 2, 3`| Duplicate items are _preserved_.|
+|`SET(1, 2, 2, 3)`|`SET(1, 2, 3)`| Duplicate items are _removed_.|
+
+<br />
+
+## DIFFERENCE(), INTERSECTION(), and UNION()  
+RCP-019.1 also added support for `DIFFERENCE()`, `INTERSECTION()`, and `UNION()`,
+which are intended to produce types in the following manner:
+  * Operations on _homogeneous_ collections of `LIST()` or `SET()` should 
+    return `LIST()` or `SET()`, respectively. For example,
+    _`UNION(LIST('a', 'b', 3+5), LIST(6))`_ should return _`LIST('a', 'b', 6, 8)`_.
+  * Operations on _heterogenous_ collections of `LIST()` or `SET()`, for 
+    instance _`DIFFERENCE(LIST(1, 2, 3), SET(3))`_ should return _`LIST()`_.      
+
+These special functions require at least two arguments of type `LIST()` or `SET()`:
+ 
+ | Expression  | Result |  Comments |
+ | :--- | :--- | :--- |
+ |`DIFFERENCE(LIST(1, 2, 3), LIST(1, 2))`|`LIST(3)`|Collection operators require two or more `LIST()` or `SET()` arguments.|
+ |`UNION(LIST(1, 2), SET(3))` |`LIST(1, 2, 3)`|Arguments of type `LIST()` are converted to `SET()`.   |
+ |`INTERSECTION(SET(DIFFERENCE(LIST(1, 2, 3), SET(1))), SET(2))`|`SET(2)`|Since the return type of `collection` operators is `SET()` or `LIST()`, they can be composed.|


### PR DESCRIPTION
Cleaned up and reorganized main README content. Updated the RCP-019 section.