### PR TITLE
Issue #62: Added context and single- and multi-valued payload formats

### DIFF
--- a/dd-json-payloads.md
+++ b/dd-json-payloads.md
@@ -3,48 +3,153 @@
 | **RCP** | 25 |
 | :--- | :--- |
 | **Version** | **1.7** |
-| **Authors** | Alexander Likholyot ([Planitar](alex@planitar.com))<br />Joshua Darnell ([RESO](mailto:josh@reso.org))<br />Paul Stusiak ([Falcon Technologies](pstusiak@falcontechnologies.com)) | |
+| **Authors** | Alexander Likholyot ([Planitar](mailto:alex@planitar.com))<br />Joshua Darnell ([RESO](mailto:josh@reso.org))<br />Paul Stusiak ([Falcon Technologies](mailto:pstusiak@falcontechnologies.com)) | |
 | **Status** | **IN PROGRESS** |
 | **Date Submitted** | February 2019 |
 | **Date Approved** | April 2019 |
 | **Dependencies** | [Data Dictionary 1.7](https://ddwiki.reso.org/display/DDW17/RESO+Data+Dictionary+1.7) |
-| **Related Links** | [RCP-022](https://github.com/RESOStandards/transport/blob/43-migrate-rcp-022-from-confluence/autofill-service.md) |
+| **Related Links** | [RESO Common Schema Open API Format](https://github.com/RESOStandards/web-api-commander/blob/main/src/main/resources/RESODataDictionary-1.7.openapi3.json) |
 
-Data Dictionary JSON Payloads are a normative standard format generated from the Data Dictionary specification that can be used with any JSON Web API.  
+Data Dictionary JSON Payloads are a normative standard format generated from the Data Dictionary specification that can be used with any JSON Web API or data source. Local data elements are also supported.  
 
 # Synopsis
-This RCP outlines the a generalized Data Dictionary JSON Schema to accompany the Lightweight Autofill proposal (RCP-022)
-and for use in any JSON Web API.
+This proposal establishes a normative JSON data format that corresponds with the RESO Data Dictionary and is compatible with existing Web API implementations for retrieving or creating data.
+
+This format is not limited to JSON Web APIs and may be used with any data source, for instance an S3 bucket or web hooks event. Both single- and multi-valued payloads are supported. Another use is as a standard format for off-chain data and distributed ledgers.
+
+Local data elements are also supported.  
 
 # Rationale
-When working with RESO Data Dictionary data, it's convenient to be able to pick that data up from any JSON Web API URL.
+The RESO Web API is used primarily by MLS data providers, and it's important they provide a common interface for metadata, query support, and payload formats throughout the MLS landscape due to its decentralized nature. The RESO Web API provides a standard API Gateway for the MLS domain.
 
-In doing so, there is a need to have a standard shape that all RESO Web API servers can understand as well. 
+There are other participants in the real estate transaction and ecosystem that benefit from having a standard payload format to provide interoperability between various systems. For example, assessment or showing providers. 
 
-This proposal doesn't introduce any new Data Dictionary items. Rather, it presents a normative reference for the data shape 
-expected in transports that don't use the RESO Web API directly, such as [RCP-022](https://github.com/RESOStandards/transport/blob/43-migrate-rcp-022-from-confluence/autofill-service.md).
+In these cases, their API services might be structured differently than the RESO Web API standard but the data is in the same format and therefore is interoperable with other providers.
+
 
 # Proposal
-In the Lightweight Autofill Service proposal ([RCP-022](https://github.com/RESOStandards/transport/blob/43-migrate-rcp-022-from-confluence/autofill-service.md)), 
-a RESO Web API server is expected to retrieve data from an external source and attach it to a Property record, either existing or in-progress, in system other than the one it originated in.
+The RESO Data Dictionary is a transport-independent representation of data models within the RESO domain.
 
-While these data could be pushed into that Web API server by means of Add/Edit ([RCP-010](./web-api-add-edit.md)) using an update client, it's much easier for 
-professionals working with real estate data (such as Photographers), to provide a url containing a lightweight payload that can be 
-loaded into a listing instead. 
+The RESO Web API uses a versioned, JSON-based representation of the Data Dictionary which is generated from its specification. 
 
-The main requirement in the preceding example is having a standard Data Dictionary JSON format to provide the record in. The URL and protocol used to
-retrieve the payload are a separate concern. 
+The goal of this proposal is to generalize that format.
 
-This proposal outlines the canonical format all Data Dictionary JSON payloads should follow.
+## Context
+When using the RESO Web API clients can infer the Data Dictionary models they're representing, as there's a normative URI structure that corresponds to advertised data elements.
 
-## Case 1: Record Does Not Include Keys for Existing Records
-In this case, using the example of the Autofill Service, no keys have been provided 
-and records are expected to be created for all resource data contained in the payload. 
+When working with Data Dictionary JSON Payloads, the context of the data isn't clear. 
 
-The Autofill data provider would submit a URI to the Web API host, which would resolve to a payload similar to the following:
+In order to address this, a special context variable will be added to RESO Data Dictionary data to indicate which model and version is being represented in the payload. 
+
+RESO has a [Uniform Resource Name (URN) namespace](https://www.iana.org/assignments/urn-formal/reso) registered with IANA. 
+
+Section 3.4.1 of this proposal shows a representation of a versioned Data Dictionary resource: 
+
+```
+3.4.1 RESO Data Dictionary Metadata Elements
+  (a) Versioned Metadata Resource Element
+
+      Format:
+        urn:reso:metadata:{version}:resource:{resource-name}
+
+      where "version" MAY have values such as "1.6" or "1.7", and
+      "resource-name¨ is one of "Property", "Member", "Office", or 
+      other resource definitions RESO provides (see references).
+
+      Example: 
+        urn:reso:metadata:1.7:resource:property
+```
+
+[**READ MORE about URNs**](https://en.wikipedia.org/wiki/Uniform_Resource_Name)
+
+For each of the payload formats described in the proposal, a context variable will be added to indicate which Data Dictionary model it's referring to. 
+
+**Example**
+
+RESO Context variable for a Data Dictionary 1.7 Property Resource:
 
 ```
 {
+  "@reso.context": "urn:reso:metadata:1.7:resource:property",
+  ...
+}
+```
+
+Those working with the Data Dictionary JSON format should be prepared to extract versioned standard data elements such as fields and lookups using RESO reference metadata, as there may be local data in the payload whose schema is unknown ahead of time. 
+
+There are metadata resources and services available to assist in doing this. Please contact dev@reso.org for more information. 
+
+Since the Data Dictionary also defines related objects or collections for each resource, such as ListAgent as a Member record or Media as a collection of Media items in a Property Resource, the versioned resource in the URN provides enough information to interpret these items as well.
+
+Additional parameters may be added to the URN to indicate such things as a particular action that goes along with the payload.
+
+## Representations
+There are two possible representations for Data Dictionary JSON Payloads:
+* **Single-valued payloads** represent a value for a single record at the top level. 
+* **Multi-valued payloads** represent a collection of zero or more records, where zero items means the empty list `[]`.
+
+These are outlined in the following sections.
+
+### Single-Valued Payloads
+In many cases, such as Add/Edit, it's convenient to be able to represent a single, top-level JSON Data Dictionary item:
+
+```json
+{
+  "@reso.context": "urn:reso:metadata:1.7:resource:property",
+  "Country": "CA",
+  "StateOrProvince": "YT",
+  "City": "Dawson City",
+  "PostalCode": "Y0B 1G0",
+  "StreetName": "Bayshore Rd",
+  "StreetNumber": "1803",
+  "Media": [
+    {
+      "ResourceName": "Property",
+      "MediaCategory": "Branded Virtual Tour",
+      "MediaType": "mov",
+      "MediaURL": "https://example.com/vJVDL415WZ7GE1/",
+      "ShortDescription": "Example"
+    },
+    {
+      "ResourceName": "Property",
+      "MediaCategory": "Floor Plan",
+      "MediaType": "pdf",
+      "MediaURL": "https://example.com/vJVDL415WZ7GE1/doc/floorplan_imperial.pdf",
+      "ShortDescription": "imperial"
+    }
+  ],
+  "Rooms": [
+    {
+      "RoomType": "Dining",
+      "RoomName": "Breakfast",
+      "RoomWidth": 4.409,
+      "RoomLength": 2.977,
+      "RoomLengthWidthUnits": "Meters",
+      "RoomLengthWidthSource": "LocalProvider"
+    },
+    {
+      "RoomType": "Dining",
+      "RoomName": "Dining",
+      "RoomWidth": 4.3,
+      "RoomLength": 5.998,
+      "RoomLengthWidthUnits": "Meters",
+      "RoomLengthWidthSource": "LocalProvider"
+    }
+  ]
+}
+```
+
+It's also important to support this format to maintain interoperability with existing Web API clients and servers.
+
+### Multi-Valued Payloads
+
+Multi-valued payloads are also possible, in which case the response contains an array property called `value`, which is a collection of zero or more items corresponding to the Data Dictionary model annotated in `@reso.context`.
+
+Using the payload in the previous example:
+
+```json
+{
+  "@reso.context": "urn:reso:metadata:1.7:resource:property",
   "value": [
     {
       "Country": "CA",
@@ -90,62 +195,18 @@ The Autofill data provider would submit a URI to the Web API host, which would r
     }
   ]
 }
-
 ```
 
-Note the nested Media and Rooms arrays in the payload. The RESO Web API uses expanded data sets when related information accompanies a another record. 
-
-In this case, the Property record has Media and Rooms information as well. This allows RESO Web API servers to use the same payload for autofill 
-as they do with upsert provided through Add/Edit ([RCP-010](./web-api-add-edit.md)).
-
-## Case 2: Data Includes Keys for Existing Records
-Assume listing data already exists in the Web API host's system and the goal is to make a call to an autofill provider 
-to update existing data, such as the StreetNumber of the Property record and dimensions of one of the existing rooms. 
-
-In this case, the user would provide an autofill URI that provides response similar to that used in Case 1, 
-except now the resulting payload would contain keys for any data that was meant to be updated, as follows:
-
-```
-{
-  "value": [
-    {
-      "StreetNumber": "1804",
-      "Rooms": [
-        {
-          "RoomKey": "A34535F235",
-          "RoomWidth": 5.139,
-          "RoomLength": 3.882
-        }
-      ]
-    }
-  ]
-}
-```
-Note: in the case of upserts, the autofill provider MUST include the keys for the records to be updated. 
-
-Autofill providers are expected to return a standard `HTTP 200` status code when autofill objects are successfully
-transferred from the provider to the autofill consumer, i.e. the Web API host. 
-
-Consumers of external JSON Web API services should be prepared to render the appropriate error message in cases where the autofill object fails to transfer. 
-
-This proposal doesn't specify any additional status codes that might be used in such a scenario and instead relies on 
-existing HTTP protocol conventions for status codes. 
-
-For example, a 500 should be thrown when there's an internal server error of some kind on the autofill provider.
+Those using Data Dictionary JSON Payloads should be prepared to check for the `value` property to determine whether to interpret the payload as single- or multi-valued.
 
 # Impact
-Those wanting to implement the Autofill proposal described in [RCP-022](https://github.com/RESOStandards/transport/blob/43-migrate-rcp-022-from-confluence/autofill-service.md) and [RCP-025](https://github.com/RESOStandards/transport/new/44-migrate-rcp-025-from-confluence/dd-json-payloads.md) 
-will need to create a mechanism for retrieving autofill objects and attaching them to an existing resource in their system 
-(or use them to create new resources). 
-
-This proposal doesn't add additional requirements to the Web API specification, as its purpose is to create a data contract 
-that can be used to process external resource data into a Web API host system.
+This proposal doesn't introduce any additional requirements for current RESO Web API providers. Data Dictionary JSON Payloads are designed to be interoperable with their current formats. 
 
 # Compatibility
-RESO Data Dictionary 1.7+
+RESO Data Dictionary 1.7+.
 
 # Certification Impact
-RESO Certification is not required at this time. This may be revised given sufficient interest in having these payloads certified. 
+Draft implementations (2) have been verified and certification tools have been requested in order to provide reports in RESO Analytics.
 
 # Original Proposal
 [**Download PDF**](https://github.com/RESOStandards/transport/files/9862314/RESOWebAPIRCP-RCP.-.WEBAPI-025.Lightweight.Autofill.Schema-251022-164452.pdf)


### PR DESCRIPTION
Updating to include the `@reso.context` and single- and multi-valued payloads, as well as generalizing.