### PR TITLE
RCP-019 Grammar fixes/improvements

### DIFF
--- a/artifacts/grammars/RCP-019/rcp019.g4
+++ b/artifacts/grammars/RCP-019/rcp019.g4
@@ -28,7 +28,7 @@ options {
 // Parse an entire expression without leaving any extra input leftover
 topExp: exp EOF;
 
-exp: orExp | collectionExp | funcExp;
+exp: orExp;
 
 orExp: andExp (OR andExp)*;
 
@@ -48,7 +48,7 @@ prodExp: atomExp ((ASTERISK | SLASH | MOD) atomExp)*;
 
 // NOTE: original VE writing had that all lists of size 1 were atomExp, not list. LIST() and SET()
 // were created as a top-level item called 'collection' and should be used instead.
-atomExp: LPAREN exp RPAREN | listExp | value;
+atomExp: collectionExp | funcExp | LPAREN exp RPAREN | listExp | value;
 
 // this was left in for backwards compatibility with the first production rule, LPAREN exp RPAREN
 listExp: LPAREN (exp (COMMA exp)*)? RPAREN;

--- a/artifacts/grammars/RCP-019/rcp019.g4
+++ b/artifacts/grammars/RCP-019/rcp019.g4
@@ -25,6 +25,9 @@ options {
 	tokenVocab = rcp019Lexer;
 }
 
+// Parse an entire expression without leaving any extra input leftover
+topExp: exp EOF;
+
 exp: orExp | collectionExp | funcExp;
 
 orExp: andExp (OR andExp)*;
@@ -71,7 +74,7 @@ value:
 fieldName: (LAST)? FIELD_NAME
 	| LBRACKET (LAST)? FIELD_NAME RBRACKET;
 
-specValue: DOT FIELD_NAME DOT;
+specValue: DOT SPECOP DOT;
 charValue: QUOTED_TERM;
 timeValue: HASH ISO_TIMESTAMP HASH;
 intValue: (PLUS | MINUS)? DIGIT+;

--- a/artifacts/grammars/RCP-019/rcp019.g4
+++ b/artifacts/grammars/RCP-019/rcp019.g4
@@ -48,13 +48,17 @@ prodExp: atomExp ((ASTERISK | SLASH | MOD) atomExp)*;
 
 // NOTE: original VE writing had that all lists of size 1 were atomExp, not list. LIST() and SET()
 // were created as a top-level item called 'collection' and should be used instead.
-atomExp: collectionExp | funcExp | LPAREN exp RPAREN | listExp | value;
+atomExp: iifExp | collectionExp | funcExp | LPAREN exp RPAREN | listExp | value;
 
 // this was left in for backwards compatibility with the first production rule, LPAREN exp RPAREN
 listExp: LPAREN (exp (COMMA exp)*)? RPAREN;
 
 // this was previously an atomExp, but was moved to the top-level for faster parsing (10x speedup)
-funcExp: func LPAREN (param (COMMA param)*)? RPAREN;
+funcExp: IDENTIFIER LPAREN (param (COMMA param)*)? RPAREN;
+
+// This could be parsed as a funcExp, but IIF is special (it doesn't evaluate its parameters before
+// executing) so it is its own type
+iifExp: IIF LPAREN param COMMA param COMMA param RPAREN;
 
 collectionExp: (LIST | SET) LPAREN (exp (COMMA exp)*)? RPAREN
 	| (UNION | INTERSECTION | DIFFERENCE) LPAREN (
@@ -71,14 +75,11 @@ value:
 	| floatValue
 	| timeValue;
 
-fieldName: (LAST)? FIELD_NAME
-	| LBRACKET (LAST)? FIELD_NAME RBRACKET;
+fieldName: (LAST)? IDENTIFIER
+	| LBRACKET (LAST)? IDENTIFIER RBRACKET;
 
 specValue: DOT SPECOP DOT;
 charValue: QUOTED_TERM;
 timeValue: HASH ISO_TIMESTAMP HASH;
 intValue: (PLUS | MINUS)? DIGIT+;
 floatValue: intValue DOT DIGIT+;
-
-// SPECFUNC was added. LOCALFUNC could be added as well, with corresponding known local functions
-func: SPECFUNC | ALPHANUM;

--- a/artifacts/grammars/RCP-019/rcp019Lexer.g4
+++ b/artifacts/grammars/RCP-019/rcp019Lexer.g4
@@ -1,5 +1,31 @@
 lexer grammar rcp019Lexer;
 
+SPECFUNC: IIF | MATCH;
+WS: [ \t\n\r]+ -> skip;
+// TODO: Dynamically fill in your FIELD_NAMEs here
+FIELD_NAME:
+	'ListPrice'
+	| 'Status'
+	| 'CloseDate'
+	| 'Bedrooms'
+	| 'Bathrooms';
+SPECOP:
+	EMPTY
+	| TRUE
+	| FALSE
+	| TODAY
+	| NOW
+	| ENTRY
+	| OLDVALUE
+	| MEMBER_LOGIN_ID
+	| MEMBER_MLS_SECURITY_CLASS
+	| MEMBER_TYPE
+	| MEMBER_MLS_ID
+	| OFFICE_BROKER_MLS_ID
+	| OFFICE_MLS_ID
+	| UPDATEACTION
+	| ANY;
+
 CONCAT: PIPE;
 LPAREN: '(';
 RPAREN: ')';
@@ -70,33 +96,6 @@ DIGIT: ('0' ..'9');
 // special tokens
 RESO_SPECIAL_TOKENS: FIELD_NAME | SPECOP;
 
-// TODO: Dynamically fill in your FIELD_NAMEs here
-FIELD_NAME:
-	'ListPrice'
-	| 'Status'
-	| 'CloseDate'
-	| 'Bedrooms'
-	| 'Bathrooms';
-
-SPECFUNC: IIF | MATCH;
-
-SPECOP:
-	EMPTY
-	| TRUE
-	| FALSE
-	| TODAY
-	| NOW
-	| ENTRY
-	| OLDVALUE
-	| MEMBER_LOGIN_ID
-	| MEMBER_MLS_SECURITY_CLASS
-	| MEMBER_TYPE
-	| MEMBER_MLS_ID
-	| OFFICE_BROKER_MLS_ID
-	| OFFICE_MLS_ID
-	| UPDATEACTION
-	| ANY;
-
 ALPHANUM: ALPHA (ALPHA | DIGIT)*;
 
 QUOTED_TERM: QUOTE (~[\\"])*? QUOTE | SQUOTE (~[\\'])*? SQUOTE;
@@ -117,5 +116,3 @@ DAY: [0-3] DIGIT;
 //added support for c++ style comments
 SLASH_STAR_COMMENT: '/*' .+? '*/' -> skip;
 SLASH_SLASH_COMMENT: '//' .+? ('\n' | EOF) -> skip;
-
-WS: [ \t\n\r]+ -> skip;

--- a/artifacts/grammars/RCP-019/rcp019Lexer.g4
+++ b/artifacts/grammars/RCP-019/rcp019Lexer.g4
@@ -1,14 +1,6 @@
 lexer grammar rcp019Lexer;
 
-SPECFUNC: IIF | MATCH;
 WS: [ \t\n\r]+ -> skip;
-// TODO: Dynamically fill in your FIELD_NAMEs here
-FIELD_NAME:
-	'ListPrice'
-	| 'Status'
-	| 'CloseDate'
-	| 'Bedrooms'
-	| 'Bathrooms';
 SPECOP:
 	EMPTY
 	| TRUE
@@ -64,7 +56,6 @@ MINUS: '-';
 MOD: '.MOD.';
 
 IIF: 'IIF';
-MATCH: 'MATCH';
 LAST: 'LAST';
 LIST: 'LIST';
 SET: 'SET';
@@ -90,13 +81,12 @@ MEMBER_MLS_ID: 'MEMBER_MLS_ID';
 OFFICE_BROKER_MLS_ID: 'OFFICE_BROKER_MLS_ID';
 OFFICE_MLS_ID: 'OFFICE_MLS_ID';
 
+IDENTIFIER: (ALPHA | UNDERSCORE) (ALPHANUM | UNDERSCORE)*;
 ALPHA: ('a' ..'z' | 'A' ..'Z');
 DIGIT: ('0' ..'9');
 
-// special tokens
-RESO_SPECIAL_TOKENS: FIELD_NAME | SPECOP;
-
 ALPHANUM: ALPHA (ALPHA | DIGIT)*;
+UNDERSCORE: '_';
 
 QUOTED_TERM: QUOTE (~[\\"])*? QUOTE | SQUOTE (~[\\'])*? SQUOTE;
 


### PR DESCRIPTION
I followed both the quickstart on [antlr.org](https://www.antlr.org/) and the online [lab.antlr.org](http://lab.antlr.org/) to validate the RCP-019 grammar, and I ran into issues.

Is antlr4 the tool that this grammar is supposed to work against?

If so, here's a series of commits that
* Make the grammar work against antlr4 for various simple expressions
* Fix an issue in the grammar that disallows valid expressions that start with a function, but don't end at the end of the function
* Support local names and local functions

I ran the new grammar against the following test inputs and it succeeds for all of these (when it previously only succeeded for the first section).

The script I ran to test uses `antlr4-parse` (I can't figure out how to get the version out of it, but it was `pip install`ed today, so I assume it is a recent version) and is attached at the end of the PR.

```
# Expressions that succeed without changes

1
1+1
1=1
1>2
1<2
1>=2
1<=2

# Expressions that succeed after minor fixes in the order of the lexer

1 + 1
1 = 1
.TRUE.
.FALSE.
.EMPTY.
.TRUE. .OR. .FALSE.
.TRUE. .AND. .FALSE.
(.TRUE. .OR. .FALSE.)
IIF(ListPrice>2,1,2)
IIF(ListPrice > 2, 1, 2)
MATCH(Status,"Active")
MATCH(Status, "Active")

# Expressions that cause problems when funcExp is an alternative in exp
# because they parse the function and leave the rest of the input

IIF(ListPrice = .EMPTY., 0, ListPrice) = IIF(ListPrice = .EMPTY., 0, ListPrice) + IIF(ListPrice = .EMPTY., 0, ListPrice)
MATCH(Status, "Active") .AND. MATCH(Status, "Active|Closed")

# Expressions that only parse when allowing custom names and functions

CustomName
CustomName + CustomName
CustomNameYN .OR. CustomNameYN
CustomFunc(CustomName)
MLS_CustomField + 7
IIF(ParkingTotal = .EMPTY., 0, ParkingTotal)
IIF(ParkingTotal = .EMPTY., 0, ParkingTotal) = IIF(GarageSpaces = .EMPTY., 0, GarageSpaces) + IIF(OpenParkingSpaces = .EMPTY., 0, OpenParkingSpaces)
```

<details>
<summary>run-tests.sh</summary>

```sh
#!/bin/bash

while read line; do
    if [[ $line == "#"* ]]; then
        # if the line begins with a comment, then output
        # the comment with some fancy formatting.
        echo -e "\e[1;4m$line\e[0m"
        continue;
    fi
    if [[ -z $line ]]; then
        # if the line is empty, don't try to parse it.
        echo;
        continue;
    fi

    # OK, we have a line that we want to parse.

    # There are hacky ways to get the stdout and stderr into two separate
    # variables. But instead of hacky, we'll just run the parser twice. 🤷
    stdout=$(echo $line | antlr4-parse rcp019.g4 rcp019Lexer.g4 topExp -tree 2>/dev/null)
    stderr=$(echo $line | antlr4-parse rcp019.g4 rcp019Lexer.g4 topExp -tree 2>&1 1>/dev/null)
    
    if [[ -z $stderr ]]; then
        # The parser didn't return any errors
        echo -e "\e[30;42m OK  \e[0m $line"
        echo -e "\e[2m$stdout\e[0m"
    else
        # The parser DID return errors
        echo -e "\e[30;41m NOK \e[0m $line"
        echo -e "\e[2m$stdout\e[0m"
        echo -e "\e[31m$stderr\e[0m"
    fi
done <tests.txt
```