### PR TITLE
Updated TOC to use Permalinks to Commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ Proposals that require certification must have an adopted specification and test
 | RCP | Name | Version | Date |
 | :-- | :-- | :-- | :-- |
 | [**RCP-036**](https://github.com/RESOStandards/transport/blob/e48bca32dbde6b82410629c826905a08387fa5e9/data-dictionary.md) | **Data Dictionary with Lookup Resource** | **1.7** | **Jan 2021** |
-| [**RCP-037**](https://github.com/RESOStandards/transport/blob/15cdbf2551f3af3628560ecfbe0321e9c7bafdea/README.md) | **Web API Core** | **2.0.0** | **Jan 2021** |
-| [**RCP-025**](./proposals/reso-common-format.md) | **RESO Common Format** | **1.0.0** | **Nov 2023** |
-| [**RCP-040**](./proposals/data-dictionary.md) | **Data Dictionary** | **2.0** | **Nov 2023** |
-| [**RCP-010**](./proposals/web-api-add-edit.md) | **Web API Add/Edit** | **1.0.0** | **Dec 2023** |
-| [**RCP-019**](./proposals//web-api-validation-expression.md) | **Web API Validation Expressions** | **1.0.0** | **Dec 2023** |
-| [**RCP-027**](./proposals/entity-events.md) | **EntityEvent Resource and Replication** | **1.0.0** | **Dec 2023** |
-| [**RCP-028**](./proposals/web-hooks-push.md) | **Push Replication with EntityEvent and Web Hooks** | **1.0.0** | **Dec 2023** |
+| [**RCP-037**](https://github.com/RESOStandards/transport/blob/a99fb6ca307208280ac51bca1f573e89cb67b202/proposals/web-api-core.md) | **Web API Core** | **2.0.0** | **Jan 2021** |
+| [**RCP-025**](https://github.com/RESOStandards/transport/blob/a99fb6ca307208280ac51bca1f573e89cb67b202/proposals/reso-common-format.md) | **RESO Common Format** | **1.0.0** | **Nov 2023** |
+| [**RCP-040**](https://github.com/RESOStandards/transport/blob/a99fb6ca307208280ac51bca1f573e89cb67b202/proposals/data-dictionary.md) | **Data Dictionary** | **2.0** | **Nov 2023** |
+| [**RCP-010**](https://github.com/RESOStandards/transport/blob/a99fb6ca307208280ac51bca1f573e89cb67b202/proposals/web-api-add-edit.md) | **Web API Add/Edit** | **1.0.0** | **Dec 2023** |
+| [**RCP-019**](https://github.com/RESOStandards/transport/blob/a99fb6ca307208280ac51bca1f573e89cb67b202/proposals/web-api-validation-expression.md) | **Web API Validation Expressions** | **1.0.0** | **Dec 2023** |
+| [**RCP-027**](https://github.com/RESOStandards/transport/blob/a99fb6ca307208280ac51bca1f573e89cb67b202/proposals/entity-events.md) | **EntityEvent Resource and Replication** | **1.0.0** | **Dec 2023** |
+| [**RCP-028**](https://github.com/RESOStandards/transport/blob/a99fb6ca307208280ac51bca1f573e89cb67b202/proposals/web-hooks-push.md) | **Push Replication with EntityEvent and Web Hooks** | **1.0.0** | **Dec 2023** |
 | [**RCP-039**](https://github.com/RESOStandards/transport/blob/22-web-api-core-210-specification/web-api-core.md) | **Web API Core** | **2.1.0** | **Dec 2023** |
 
 <br />


### PR DESCRIPTION
Updated TOC to use permalinks to underlying specs per-version rather than the generic spec.