### PR TITLE
Add Pagefind search to GitHub Pages site

### DIFF
--- a/.github/pages/_layouts/default.html
+++ b/.github/pages/_layouts/default.html
@@ -408,7 +408,80 @@
       background: var(--reso-blue-light);
       border-radius: 0 0.25rem 0.25rem 0;
     }
+
+    /* Search trigger button */
+    .search-trigger {
+      background: rgba(255,255,255,0.15);
+      border: 1px solid rgba(255,255,255,0.25);
+      border-radius: 0.375rem;
+      color: rgba(255,255,255,0.7);
+      font-size: 0.8125rem;
+      padding: 0.375rem 0.75rem;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      transition: background 0.15s, border-color 0.15s;
+    }
+    .search-trigger:hover {
+      background: rgba(255,255,255,0.25);
+      border-color: rgba(255,255,255,0.4);
+      color: white;
+    }
+    .search-trigger svg { width: 14px; height: 14px; fill: currentColor; }
+    .search-trigger kbd {
+      font-family: inherit;
+      font-size: 0.6875rem;
+      background: rgba(255,255,255,0.15);
+      border-radius: 0.25rem;
+      padding: 0.125rem 0.375rem;
+      margin-left: 0.25rem;
+    }
+
+    /* Search modal overlay */
+    .search-modal-overlay {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,0.5);
+      z-index: 100;
+      align-items: flex-start;
+      justify-content: center;
+      padding-top: 10vh;
+    }
+    .search-modal-overlay.active { display: flex; }
+    .search-modal {
+      background: white;
+      border-radius: 0.75rem;
+      width: 90%;
+      max-width: 640px;
+      max-height: 70vh;
+      overflow: hidden;
+      box-shadow: 0 20px 60px rgba(0,0,0,0.3);
+      display: flex;
+      flex-direction: column;
+    }
+    .search-modal-body {
+      padding: 1rem;
+      overflow-y: auto;
+      flex: 1;
+    }
+
+    /* Pagefind UI overrides */
+    .pagefind-ui .pagefind-ui__search-input {
+      border-radius: 0.375rem !important;
+      border-color: var(--reso-gray-200) !important;
+      font-size: 1rem !important;
+    }
+    .pagefind-ui .pagefind-ui__search-input:focus {
+      border-color: var(--reso-blue) !important;
+      box-shadow: 0 0 0 3px rgba(0,126,158,0.15) !important;
+    }
+    .pagefind-ui .pagefind-ui__result-link {
+      color: var(--reso-navy) !important;
+    }
   </style>
+  <link href="/pagefind/pagefind-ui.css" rel="stylesheet">
 </head>
 <body>
   <header class="site-header">
@@ -422,12 +495,64 @@
       <a href="https://tools.reso.org">RESO Tools</a>
       <a href="https://certification.reso.org">Certification</a>
       <a href="https://reso.org">RESO.org</a>
+      <button class="search-trigger" id="searchTrigger" type="button">
+        <svg viewBox="0 0 24 24"><path d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/></svg>
+        Search<kbd>/</kbd>
+      </button>
     </nav>
   </header>
 
   <main class="site-main">
     {{ content }}
   </main>
+
+  <!-- Search modal -->
+  <div class="search-modal-overlay" id="searchOverlay">
+    <div class="search-modal">
+      <div class="search-modal-body">
+        <div id="search"></div>
+      </div>
+    </div>
+  </div>
+
+  <script src="/pagefind/pagefind-ui.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      new PagefindUI({
+        element: '#search',
+        showSubResults: true,
+        showImages: false,
+        resetStyles: false
+      });
+
+      var overlay = document.getElementById('searchOverlay');
+      var trigger = document.getElementById('searchTrigger');
+
+      trigger.addEventListener('click', function() {
+        overlay.classList.add('active');
+        setTimeout(function() {
+          var input = overlay.querySelector('.pagefind-ui__search-input');
+          if (input) input.focus();
+        }, 100);
+      });
+
+      overlay.addEventListener('click', function(e) {
+        if (e.target === overlay) overlay.classList.remove('active');
+      });
+
+      document.addEventListener('keydown', function(e) {
+        if (e.key === '/' && !e.ctrlKey && !e.metaKey && document.activeElement.tagName !== 'INPUT' && document.activeElement.tagName !== 'TEXTAREA') {
+          e.preventDefault();
+          overlay.classList.add('active');
+          setTimeout(function() {
+            var input = overlay.querySelector('.pagefind-ui__search-input');
+            if (input) input.focus();
+          }, 100);
+        }
+        if (e.key === 'Escape') overlay.classList.remove('active');
+      });
+    });
+  </script>
 
   <footer class="site-footer">
     <p>&copy; {{ 'now' | date: '%Y' }} <a href="https://reso.org">Real Estate Standards Organization (RESO)</a>. All rights reserved.</p>

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -79,6 +79,9 @@ jobs:
           source: ./.github/pages
           destination: ./_site
 
+      - name: Build search index with Pagefind
+        run: npx pagefind --site ./_site
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
 


### PR DESCRIPTION
## Summary
- Adds Pagefind full-text search to transport.reso.org
- Search trigger button in the header nav bar with `/` keyboard shortcut
- Modal overlay with Escape to close and click-outside dismiss
- Pagefind build step added to Pages workflow (runs after Jekyll build)
- RESO-branded UI overrides for the search input and results

## Test plan
- [ ] Verify search button appears in nav bar after merge
- [ ] Click search button and confirm modal opens
- [ ] Press `/` key to open search, `Escape` to close
- [ ] Search for a spec name and verify results appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)