### PR TITLE
Fix Pagefind build: copy _site to writable directory

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -80,7 +80,11 @@ jobs:
           destination: ./_site
 
       - name: Build search index with Pagefind
-        run: npx pagefind --site ./_site
+        run: |
+          cp -r ./_site ./_site_writable
+          npx pagefind --site ./_site_writable
+          rm -rf ./_site
+          mv ./_site_writable ./_site
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- Fixes the Pagefind permission denied error from PR #174
- The jekyll-build-pages Docker action creates _site with root ownership
- Copies _site to a writable directory, runs Pagefind there, then swaps it back

## Test plan
- [ ] Pages workflow completes successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)