### PR TITLE
fix(generate-dd-json): pass PR-comment body via env, not template interpolation

### DIFF
--- a/.github/workflows/generate-dd-json.yml
+++ b/.github/workflows/generate-dd-json.yml
@@ -117,14 +117,19 @@ jobs:
       - name: Post PR comment
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
+        # Pass the comment body through the environment, not via `${{ }}` interpolation into the
+        # script. The body is markdown containing backticks; interpolating it into a JS template
+        # literal lets those backticks break out of the string (SyntaxError). Reading process.env
+        # treats it as an opaque string.
+        env:
+          COMMENT_BODY: ${{ steps.diff.outputs.comment }}
         with:
           script: |
-            const body = `${{ steps.diff.outputs.comment }}`;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body
+              body: process.env.COMMENT_BODY,
             });
 
       - name: Commit regenerated JSON back to main (push only)


### PR DESCRIPTION
Fixes the `Post PR comment` step in `generate-dd-json`, which fails with `SyntaxError: Unexpected identifier 'references'`.

## Cause

The step built the github-script body as a JS template literal with the comment interpolated in:

```js
const body = `${{ steps.diff.outputs.comment }}`;
```

The comment is markdown containing backticks (`` `dd-{ver}.json` ``, `` `references/dd/tools` ``, …). When that text is interpolated into the `` `...` `` literal, the backticks close the string early and the following words parse as bare identifiers.

Latent until now — the workflow had never reached this step (it failed earlier on the reso-tools/xlsx dependency), so #214 making **generate + fitness pass** is what first exposed it.

## Fix

Pass the body through the environment and read `process.env` in the script — the standard safe pattern, no interpolation into code:

```yaml
env:
  COMMENT_BODY: ${{ steps.diff.outputs.comment }}
with:
  script: |
    await github.rest.issues.createComment({ ..., body: process.env.COMMENT_BODY });
```

This workflow only triggers on XLSX changes, so it won't run on this PR; #212/#213 (rebased onto main) exercise the full pipeline and will confirm green once this lands and they re-rebase.
