### PR TITLE
generate-dd-json: commit to the PR branch, add lint gate + comment, share build timestamp

### DIFF
--- a/.github/workflows/generate-dd-json.yml
+++ b/.github/workflows/generate-dd-json.yml
@@ -26,6 +26,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # On a PR, check out the head branch itself (not the detached merge ref) so the regenerated
+          # JSON can be committed straight back to it. On push to main this resolves to main.
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -59,12 +62,33 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p references/dd/json
+          # One timestamp for the whole build, so every dd-{ver}.json shares the same generatedOn.
+          export DD_GENERATED_ON="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
           for v in ${{ steps.versions.outputs.list }}; do
             xlsx="references/dd/RESODataDictionary-${v}.xlsx"
             out="references/dd/json/dd-${v}.json"
             echo "Generating ${out} from ${xlsx}"
             python references/dd/tools/generate-reference-metadata.py "${xlsx}" "${v}" "${out}"
           done
+
+      - name: Lint DD sheets
+        # Read-only validation of each XLSX (structure, PascalCase, duplicates, Unicode cleanliness,
+        # SimpleDataType/LookupStatus agreement). Writes a markdown report (posted to the PR by the
+        # next step) and exits non-zero on errors — so a structurally broken sheet fails the build.
+        # Warnings do not fail; they surface in the report for in-branch fixing before merge.
+        run: |
+          set -uo pipefail
+          : > /tmp/lint-report.md
+          status=0
+          for v in ${{ steps.versions.outputs.list }}; do
+            echo "### DD ${v}" >> /tmp/lint-report.md
+            echo '```text' >> /tmp/lint-report.md
+            python references/dd/tools/dd-sheet-linter.py "references/dd/RESODataDictionary-${v}.xlsx" >> /tmp/lint-report.md 2>&1 || status=1
+            echo '```' >> /tmp/lint-report.md
+            echo >> /tmp/lint-report.md
+          done
+          cat /tmp/lint-report.md
+          exit "${status}"
 
       - name: Run DD reference fitness checks
         run: |
@@ -129,17 +153,46 @@ jobs:
               body: process.env.COMMENT_BODY,
             });
 
-      - name: Commit regenerated JSON back to main (push only)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      - name: Post lint comment
+        # success() || failure() => runs even when the lint gate above failed, so the report (errors
+        # included) reaches the PR for in-branch fixing. Reads the report file directly (no template
+        # interpolation); skips quietly if the lint step never produced one.
+        if: github.event_name == 'pull_request' && (success() || failure())
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let report;
+            try {
+              report = fs.readFileSync('/tmp/lint-report.md', 'utf8');
+            } catch {
+              return;
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '## DD sheet validation\n\n' + report,
+            });
+
+      - name: Commit regenerated JSON to the PR branch (pull_request only)
+        # Push the regenerated JSON to the PR's own (unprotected) branch — never to protected main,
+        # which rejects direct pushes. The JSON then lands on main through the PR like any other
+        # change. Same-repo PRs only (a fork's token is read-only). The [skip ci] tag stops this
+        # commit from re-triggering the workflow. On merge, the push-to-main run re-runs generate +
+        # fitness as a post-merge check but commits nothing.
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add references/dd/json/dd-*.json
           if git diff --cached --quiet; then
-            echo "No JSON changes to commit."
+            echo "JSON already up to date — nothing to commit."
             exit 0
           fi
           versions="${{ steps.versions.outputs.list }}"
           git commit -m "Regenerate DD reference JSON (${versions}) [skip ci]"
-          git push origin HEAD:main
+          git push origin "HEAD:${{ github.head_ref }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,9 +35,10 @@ All DD reference tooling lives in [`references/dd/tools/`](references/dd/tools/)
 
 **Automated — the [`generate-dd-json`](.github/workflows/generate-dd-json.yml) workflow** runs on any change to `references/dd/RESODataDictionary-*.xlsx`:
 
-- Regenerates `references/dd/json/dd-{ver}.json` from each XLSX via `generate-reference-metadata.py`.
-- Runs `check-dd-reference-fitness.py` over the generated JSON; a fitness failure fails the build.
-- On a pull request it posts a summary comment with per-version counts; on a push to `main` it commits the regenerated JSON back to `main`.
+- Regenerates `references/dd/json/dd-{ver}.json` from each XLSX via `generate-reference-metadata.py` (one shared `generatedOn` per build).
+- Validates each sheet with `dd-sheet-linter.py` (gates on errors) and runs `check-dd-reference-fitness.py` over the generated JSON (gates on failures).
+- **On a pull request:** commits the regenerated JSON back to the **PR branch** — so it lands on `main` through the PR, never a direct push to protected `main` — and posts the per-version counts and the lint report as comments, so issues are fixable in-branch before merge.
+- **On merge to `main`:** re-runs generate + lint + fitness as a post-merge check, committing nothing.
 
 **The tools** (all Python + openpyxl):
 

--- a/references/dd/json/dd-1.7.json
+++ b/references/dd/json/dd-1.7.json
@@ -1,7 +1,7 @@
 {
   "description": "RESO Data Dictionary 1.7 Reference Metadata",
   "version": "1.7",
-  "generatedOn": "2026-06-05T06:11:27.280Z",
+  "generatedOn": "2026-06-22T17:49:26.000Z",
   "resources": [
     "ContactListingNotes",
     "ContactListings",

--- a/references/dd/json/dd-2.0.json
+++ b/references/dd/json/dd-2.0.json
@@ -1,7 +1,7 @@
 {
   "description": "RESO Data Dictionary 2.0 Reference Metadata",
   "version": "2.0",
-  "generatedOn": "2026-06-05T06:11:32.276Z",
+  "generatedOn": "2026-06-22T17:49:26.000Z",
   "resources": [
     "Association",
     "Caravan",

--- a/references/dd/tools/generate-reference-metadata.py
+++ b/references/dd/tools/generate-reference-metadata.py
@@ -19,6 +19,7 @@ Usage: python3 generate-reference-metadata.py <xlsx-path> <version> [output-path
 from __future__ import annotations
 
 import json
+import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -222,7 +223,12 @@ def build_lookups(lookups_raw: list[dict]) -> list[dict]:
 
 
 def iso_now() -> str:
-    """Match JavaScript new Date().toISOString(): millisecond precision, 'Z' suffix."""
+    """generatedOn timestamp. Prefer DD_GENERATED_ON from the environment so every file produced in a
+    single build shares one timestamp (the workflow sets it once); fall back to the current time for
+    ad-hoc local runs (millisecond precision + 'Z', matching JS new Date().toISOString())."""
+    override = os.environ.get("DD_GENERATED_ON")
+    if override:
+        return override
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
 
 


### PR DESCRIPTION
Reworks the `generate-dd-json` workflow so the commit-back works with branch protection, adds the linter as a validation gate, and shares one build timestamp.

## Why

After #212/#213 merged, the old `Commit regenerated JSON back to main` step failed with `GH006: protected branch ... must be made through a pull request` — so the auto-commit never landed and the committed JSON went stale (missing the BuiltPre1978YN / ClassName corrections).

## The flow now

**On a PR (XLSX changed):** generate JSON → **lint** each sheet → **fitness** → post the counts + lint report as comments → **commit the regenerated JSON back to the PR branch** (`[skip ci]`). The JSON lands on `main` *through the PR*, never via a direct push to protected `main`. Issues are visible and fixable in the same branch before merge.

**On merge to `main`:** re-runs generate + lint + fitness as a post-merge check, commits nothing.

## What changed

- **Commit target:** the PR's own branch, not protected `main` (checkout uses `github.head_ref`; same-repo PRs only).
- **Linter gate:** `dd-sheet-linter.py` runs on every sheet — errors fail the build, warnings surface in a `DD sheet validation` PR comment (verified gate-safe: all three current sheets exit 0, warnings only).
- **Shared `generatedOn`:** the workflow sets `DD_GENERATED_ON` once so all three `dd-{ver}.json` share one timestamp (generator falls back to `now()` for local runs). Keeps `generatedOn` (the hosted DD references layer surfaces it) while making each build's set consistent.
- **JSON refresh:** the committed `dd-{ver}.json` are regenerated from the corrected sheets, bringing them back in sync.

## Validation

YAML parses; the lint loop and generate/fitness were run locally (lint exits 0, fitness passes, JSON matches the corrected sheets). This PR doesn't change an XLSX, so `generate-dd-json` won't run on it — once it merges I'll exercise the full PR flow (generate + lint + fitness + comments + commit-to-branch) with a throwaway XLSX re-save and confirm it end-to-end before relying on it.
