### PR TITLE
dd-sheet-linter: fix two false-signal checks (name-match -> empty-enumeration; synonyms -> per-resource)

### DIFF
--- a/.reso/tools/dd/dd-sheet-linter.py
+++ b/.reso/tools/dd/dd-sheet-linter.py
@@ -17,7 +17,7 @@ Checks:
   5. Unicode cleanliness (no BOM, NBSP, ZWSP, ZWNJ, ZWJ)
   6. Enumerated lookups define values (a non-Open LookupStatus requires at least one value)
   7. Deprecation tracking vs. previous version (warnings, not errors)
-  8. Synonym not equal to any StandardName
+  8. Synonym collides with a StandardName on the same resource (synonyms are enforced per-resource)
   9. Version Info sheet has valid version
  10. No empty StandardName / StandardLookupValue cells in data rows
  11. SimpleDataType and LookupStatus agree (a field is an enumeration IFF its type is a String List)
@@ -121,6 +121,35 @@ def empty_enumeration_errors(
         seen.add(name)
         if name not in with_values:
             out.append(f'Lookup "{name}" is declared "{status}" but defines no values')
+    return out
+
+
+def synonym_collisions(
+    fields_data, field_name_col="StandardName", resource_col="ResourceName", synonym_col="Synonyms"
+) -> list[str]:
+    """Field synonyms are enforced PER RESOURCE (Commander DataDictionary.java:
+    container.getFieldMap(resourceName).containsKey(synonym)), so a synonym conflicts only when it is
+    also a StandardName on the SAME resource. A cross-resource match is not a conflict and must not be
+    flagged: e.g. Member.SourceSystemMemberKey lists SourceSystemAgentKey as a synonym, and
+    Showing.SourceSystemAgentKey is a legitimate standard field on a different resource. Returns one
+    message per same-resource collision; the caller decides severity."""
+    names_by_resource: dict = {}
+    for row in fields_data:
+        resource = row.get(resource_col)
+        name = row.get(field_name_col)
+        if resource and name:
+            names_by_resource.setdefault(resource, set()).add(name)
+    out: list[str] = []
+    for row in fields_data:
+        synonyms = row.get(synonym_col)
+        if not isinstance(synonyms, str):
+            continue
+        resource = row.get(resource_col)
+        field = row.get(field_name_col)
+        same_resource = names_by_resource.get(resource, set())
+        for syn in (s.strip() for s in synonyms.split(",")):
+            if syn and syn != field and syn in same_resource:
+                out.append(f'Synonym "{syn}" for {resource}.{field} is also a StandardName on {resource}')
     return out
 
 
@@ -271,18 +300,12 @@ def main() -> None:
                 shown = ", ".join(added_l[:5]) + ("..." if len(added_l) > 5 else "")
                 add_info("additions", f"{len(added_l)} lookup(s) added: {shown}")
 
-    # ── 8. Synonym not equal to any StandardName ──
+    # ── 8. Synonym collides with a StandardName on the same resource ──
+    # Synonyms are enforced per-resource, so a synonym is only a conflict when it is also a
+    # StandardName on the SAME resource. A cross-resource match is not a conflict (see synonym_collisions).
     if synonym_col:
-        for row in fields_data:
-            synonyms = row.get(synonym_col)
-            if not isinstance(synonyms, str):
-                continue
-            for syn in (s.strip() for s in synonyms.split(",")):
-                if syn and syn in all_field_names:
-                    add_warning(
-                        "synonym-collision",
-                        f'Synonym "{syn}" for field "{row.get(field_name_col)}" is also a StandardName',
-                    )
+        for msg in synonym_collisions(fields_data, field_name_col, resource_col, synonym_col):
+            add_warning("synonym-collision", msg)
 
     # ── 9. Version Info ──
     if "Version Info" in wb.sheetnames:

--- a/.reso/tools/dd/dd-sheet-linter.py
+++ b/.reso/tools/dd/dd-sheet-linter.py
@@ -15,7 +15,7 @@ Checks:
   3. No duplicate (Resource, FieldName) pairs
   4. No duplicate (LookupName, StandardLookupValue) pairs
   5. Unicode cleanliness (no BOM, NBSP, ZWSP, ZWNJ, ZWJ)
-  6. Referential integrity (LookupName -> field with lookup type)
+  6. Enumerated lookups define values (a non-Open LookupStatus requires at least one value)
   7. Deprecation tracking vs. previous version (warnings, not errors)
   8. Synonym not equal to any StandardName
   9. Version Info sheet has valid version
@@ -89,6 +89,38 @@ def type_status_warnings(fields_data, field_name_col="StandardName", resource_co
                 f"{label}: SimpleDataType={data_type!r} is an enumeration data type "
                 f"but carries no LookupStatus"
             )
+    return out
+
+
+def empty_enumeration_errors(
+    fields_data,
+    lookups_data,
+    lookup_name_col="LookupName",
+    lookup_value_col="StandardLookupValue",
+    status_col="LookupStatus",
+) -> list[str]:
+    """A field binds to a LookupName; that name need not match the field's own name, and RESO reuses
+    (or a vendor re-scopes) a value set across fields, so a LookupName matching a field name is not an
+    invariant. The real rule: a lookup whose LookupStatus is anything other than 'Open' must define at
+    least one value. 'Open' lookups are provider-defined and legitimately carry no RESO values.
+    Returns one message per offending LookupName (deduplicated); the caller decides severity."""
+    with_values = {
+        row.get(lookup_name_col)
+        for row in lookups_data
+        if row.get(lookup_name_col) and row.get(lookup_value_col)
+    }
+    seen: set = set()
+    out: list[str] = []
+    for row in fields_data:
+        name = row.get(lookup_name_col)
+        status = row.get(status_col)
+        if not name or not status or str(status).strip() == "Open":
+            continue
+        if name in seen:
+            continue
+        seen.add(name)
+        if name not in with_values:
+            out.append(f'Lookup "{name}" is declared "{status}" but defines no values')
     return out
 
 
@@ -198,12 +230,12 @@ def main() -> None:
     check_unicode(wb["Fields"], "Fields")
     check_unicode(wb["Lookups"], "Lookups")
 
-    # ── 6. Referential integrity (LookupName -> field) ──
-    lookup_field_names = {row.get(lookup_name_col) for row in lookups_data if row.get(lookup_name_col)}
-    for lookup_name in lookup_field_names:
-        name = str(lookup_name)
-        if name not in all_field_names and "Type" not in name and "Status" not in name:
-            add_info("referential", f'LookupName "{name}" has no exact field match (may be shared)')
+    # ── 6. Enumerated lookups must define values ──
+    # There is no rule that a LookupName matches a field name (RESO shares sets across fields, and a
+    # vendor may re-scope them), so name matching would be a false signal. The real invariant: a
+    # non-"Open" LookupStatus must carry at least one value.
+    for msg in empty_enumeration_errors(fields_data, lookups_data, lookup_name_col, lookup_value_col):
+        add_error("empty-enumeration", msg)
 
     # ── 7. Deprecation tracking vs. previous version ──
     if prev_wb is not None and "Fields" in prev_wb.sheetnames:

--- a/.reso/tools/dd/test_dd_sheet_linter.py
+++ b/.reso/tools/dd/test_dd_sheet_linter.py
@@ -159,6 +159,46 @@ def test_empty_enumeration_skips_open_and_unbound_fields():
     assert linter.empty_enumeration_errors(fields, []) == []
 
 
+# --- synonym_collisions (per-resource, matching Commander enforcement) ---------------------------
+
+
+def _syn_fields(*rows) -> list[dict]:
+    """(ResourceName, StandardName, Synonyms) -> sheet_to_dicts shape."""
+    cols = ["ResourceName", "StandardName", "Synonyms"]
+    return [{c: v for c, v in zip(cols, r) if v is not None} for r in rows]
+
+
+def test_synonym_collision_flags_same_resource():
+    # A synonym that is also a StandardName on the SAME resource is a real contradiction.
+    fields = _syn_fields(
+        ("Property", "StructureType", "OtherName"),
+        ("Property", "OtherName", None),  # OtherName is a StandardName on Property
+    )
+    errs = linter.synonym_collisions(fields)
+    assert len(errs) == 1
+    assert "OtherName" in errs[0] and "Property" in errs[0]
+
+
+def test_synonym_collision_ignores_cross_resource():
+    # The real DD shape: Member.SourceSystemMemberKey lists SourceSystemAgentKey as a synonym, and
+    # SourceSystemAgentKey is a legitimate standard field on Showing -> NOT a conflict.
+    fields = _syn_fields(
+        ("Member", "SourceSystemMemberKey", "SourceSystemAgentKey"),
+        ("Showing", "SourceSystemAgentKey", None),
+    )
+    assert linter.synonym_collisions(fields) == []
+
+
+def test_synonym_collision_ignores_self_reference():
+    fields = _syn_fields(("Property", "Foo", "Foo"))  # a field listing its own name is not a collision
+    assert linter.synonym_collisions(fields) == []
+
+
+def test_synonym_collision_handles_missing_synonyms():
+    fields = _syn_fields(("Property", "Foo", None), ("Property", "Bar", ""))
+    assert linter.synonym_collisions(fields) == []
+
+
 # --- end-to-end (full validator over a fixture workbook) -----------------------------------------
 
 

--- a/.reso/tools/dd/test_dd_sheet_linter.py
+++ b/.reso/tools/dd/test_dd_sheet_linter.py
@@ -102,6 +102,63 @@ def test_agreement_skips_rows_without_field_name():
     assert linter.type_status_warnings(rows) == []
 
 
+# --- empty_enumeration_errors (a non-Open LookupStatus must define values) -----------------------
+
+
+def _enum_fields(*rows) -> list[dict]:
+    """(ResourceName, StandardName, LookupName, LookupStatus) -> sheet_to_dicts shape."""
+    cols = ["ResourceName", "StandardName", "LookupName", "LookupStatus"]
+    return [{c: v for c, v in zip(cols, r) if v is not None} for r in rows]
+
+
+def _lookups(*rows) -> list[dict]:
+    """(LookupName, StandardLookupValue) -> sheet_to_dicts shape."""
+    cols = ["LookupName", "StandardLookupValue"]
+    return [{c: v for c, v in zip(cols, r) if v is not None} for r in rows]
+
+
+def test_empty_enumeration_flags_non_open_without_values():
+    fields = _enum_fields(
+        ("Property", "MlsStatus", "MlsStatus", "Locked with Enumerations"),        # has values -> ok
+        ("Property", "ExtraFeatures", "ExtraFeatures", "Open with Enumerations"),   # no values -> error
+    )
+    lookups = _lookups(("MlsStatus", "Active"), ("MlsStatus", "Closed"))
+    errs = linter.empty_enumeration_errors(fields, lookups)
+    assert len(errs) == 1
+    assert "ExtraFeatures" in errs[0] and "Open with Enumerations" in errs[0]
+
+
+def test_empty_enumeration_ignores_open_lookups():
+    # Open lookups are provider-defined and legitimately carry no RESO values.
+    fields = _enum_fields(("Property", "City", "City", "Open"))
+    assert linter.empty_enumeration_errors(fields, []) == []
+
+
+def test_empty_enumeration_passes_when_values_present():
+    fields = _enum_fields(("Field", "Type", "FieldDataTypes", "Open with Enumerations"))
+    lookups = _lookups(("FieldDataTypes", "Edm.String"), ("FieldDataTypes", "Edm.Int64"))
+    assert linter.empty_enumeration_errors(fields, lookups) == []
+
+
+def test_empty_enumeration_dedupes_shared_lookup():
+    # A shared LookupName bound by several non-Open fields is reported once, not per field.
+    fields = _enum_fields(
+        ("Property", "A", "SharedEnum", "Open with Enumerations"),
+        ("Member", "B", "SharedEnum", "Locked with Enumerations"),
+    )
+    errs = linter.empty_enumeration_errors(fields, [])  # SharedEnum defines no values
+    assert len(errs) == 1
+    assert "SharedEnum" in errs[0]
+
+
+def test_empty_enumeration_skips_open_and_unbound_fields():
+    fields = _enum_fields(
+        ("Property", "ListPrice", None, None),        # no lookup binding -> skipped
+        ("Property", "SomeEnum", "SomeEnum", None),   # no LookupStatus -> skipped (caught by §11 instead)
+    )
+    assert linter.empty_enumeration_errors(fields, []) == []
+
+
 # --- end-to-end (full validator over a fixture workbook) -----------------------------------------
 
 
@@ -129,3 +186,29 @@ def test_end_to_end_flags_and_exits_nonzero():
     assert "badName" in result.stdout
     assert "type-status-agreement" in result.stdout
     assert "HistoryTransactional.ClassName" in result.stdout
+
+
+def test_end_to_end_flags_empty_enumeration():
+    wb = Workbook()
+    fields = wb.active
+    fields.title = "Fields"
+    fields.append(["ResourceName", "StandardName", "SimpleDataType", "LookupName", "LookupStatus"])
+    fields.append(["Property", "GoodEnum", "String List, Single", "GoodEnum", "Open with Enumerations"])   # has value -> ok
+    fields.append(["Property", "BadEnum", "String List, Single", "BadEnum", "Locked with Enumerations"])   # no value -> error
+    fields.append(["Property", "OpenEnum", "String List, Single", "OpenEnum", "Open"])                     # open -> ok
+    lookups = wb.create_sheet("Lookups")
+    lookups.append(["LookupName", "StandardLookupValue"])
+    lookups.append(["GoodEnum", "Yes"])
+
+    with tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, "fixture.xlsx")
+        wb.save(path)
+        result = subprocess.run(
+            [sys.executable, str(_LINTER_PATH), path], capture_output=True, text=True
+        )
+
+    assert result.returncode == 1  # the empty enumeration is an error
+    assert "empty-enumeration" in result.stdout
+    assert "BadEnum" in result.stdout
+    assert result.stdout.count("defines no values") == 1  # only BadEnum; GoodEnum + OpenEnum are clean
+    assert "referential" not in result.stdout  # the removed name-match note must not resurface


### PR DESCRIPTION
## Summary

Two of the linter's checks emitted false signals by scanning globally for a rule that is actually per-resource, or for a rule that does not exist. This grounds both in the real enforcement, and adds a genuine integrity check in the slot the first one vacated.

## 1. Replace the `[referential]` name-match note with an empty-enumeration check

The `[referential]` note flagged every `LookupName` that was not also a field name – but there is no such rule: a field binds to a `LookupName` regardless of its own name, RESO reuses (or a vendor re-scopes) a value set across fields, and open enumerations legitimately have no values. So it produced only false signals – 18 on DD 2.1, every one a shared or open lookup behaving as designed. On a public PR that reads as a referential defect where none exists.

Replaced with the real invariant: a lookup whose `LookupStatus` is anything other than `Open` must define at least one value. `Open` lookups are provider-defined and legitimately empty. Emitted as an error; silent across DD 1.7 / 2.0 / 2.1 today.

## 2. Scope the synonym-collision check per-resource

Field synonyms are enforced per-resource in the Commander (`DataDictionary.java`: `container.getFieldMap(resourceName).containsKey(synonym)`), so a synonym conflicts only when it is also a `StandardName` on the **same** resource. The check was global, so it flagged cross-resource matches that are not conflicts – e.g. `Member.SourceSystemMemberKey` lists `SourceSystemAgentKey` as a synonym while `Showing.SourceSystemAgentKey` is a legitimate standard field on a different resource. That was 2–3 false signals per version, the same failure mode as the removed name-match note. Now scoped per-resource: silent on today's DD, loud only on a genuine same-resource contradiction.

## Implementation + validation

- Both checks extracted as module-level functions (`empty_enumeration_errors`, `synonym_collisions`) mirroring `type_status_warnings`, so they are unit-testable.
- Tests: 9 new cases across the two checks (empty-enum: flags / ignores Open / passes with values / dedupes shared / skips unbound; synonym: same-resource fires, cross-resource does not, self-reference ignored, missing synonyms handled), plus an end-to-end case that fails the run and confirms the `referential` note does not resurface.
- `pytest`: 17 passed. Linter over all three live sheets: no `referential`, no `synonym-collision`, `empty-enumeration` clean; **DD 2.1 now passes with zero errors and zero warnings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
