### PR TITLE
dd-linter: document why the empty-enumeration check is stricter than the runtime gate

### DIFF
--- a/.reso/tools/dd/dd-sheet-linter.py
+++ b/.reso/tools/dd/dd-sheet-linter.py
@@ -101,8 +101,19 @@ def empty_enumeration_errors(
 ) -> list[str]:
     """A field binds to a LookupName; that name need not match the field's own name, and RESO reuses
     (or a vendor re-scopes) a value set across fields, so a LookupName matching a field name is not an
-    invariant. The real rule: a lookup whose LookupStatus is anything other than 'Open' must define at
-    least one value. 'Open' lookups are provider-defined and legitimately carry no RESO values.
+    invariant. The real rule: a status that NAMES enumerations must define at least one. Any status
+    other than a bare 'Open' -- 'Open with Enumerations', 'Locked with Enumerations' -- requires a
+    value; an "Open with Enumerations" enum with no enumerations is self-contradictory (it is not, in
+    fact, open WITH enumerations). Bare 'Open' is skipped: those enums are fully provider-defined and
+    legitimately carry no RESO values.
+
+    Deliberately stricter than the runtime cert gate, and not in conflict with it. reso-tools'
+    dd-metadata-checks.ts intentionally does NOT implement a runtime "MUST contain at least one standard
+    lookup" rule (see its module header) because that rule is "incompatible with open enums that carry
+    no standard values" -- i.e. bare 'Open', which this check also exempts. The runtime leaves unchecked
+    a PROVIDER shipping no values; this check guards the DD SHEET declaring an enumerated status with an
+    empty value set before it ever ships. Different layer, different subject.
+
     Returns one message per offending LookupName (deduplicated); the caller decides severity."""
     with_values = {
         row.get(lookup_name_col)


### PR DESCRIPTION
## Summary

Follow-up to #228. The `empty_enumeration_errors` check flags any `LookupStatus` other than a bare `Open` that defines no values – including `Open with Enumerations`. That is deliberate, but #228 landed it without stating why, which leaves a check that is stricter than the runtime certification gate with no recorded rationale. This adds that rationale to the docstring. No behavior change; documentation only.

## Why the check is stricter than the runtime, and why that is correct

A status that names enumerations must define at least one. A bare `Open` promises none and is provider-defined, so it is legitimately empty and is exempt. `Open with Enumerations`, by contrast, promises standard enumerations – an `Open with Enumerations` type with no enumerations is not, in fact, open with enumerations – so an empty one is self-contradictory and is flagged. `Locked with Enumerations` is closed and must define its fixed set.

This is a sheet-integrity check, and it is deliberately stricter than the runtime certification gate without conflicting with it. The reso-tools `dd-metadata-checks.ts` module intentionally does not implement a runtime "MUST contain at least one standard lookup" rule, because that rule is incompatible with open enumerations that carry no standard values – the bare `Open` case, which this check also exempts. The runtime leaves unchecked a provider shipping no values; this check guards the DD sheet itself declaring an enumerated status with an empty value set before it ships. Different layer, different subject.

## Validation

- Documentation only – the guard, severity, and scope are unchanged from #228.
- `pytest`: 17 passed.
- Silent across DD 1.7, 2.0, and 2.1 (zero empty non-`Open` enumerations on every shipped version), so the check remains a forward guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
