### PR TITLE
fix(core): correct the 404 scenario catalog row (not a malformed query)

### DIFF
--- a/proposals/web-api-core.md
+++ b/proposals/web-api-core.md
@@ -3090,7 +3090,7 @@ This catalog is the canonical list of Web API Core test scenarios. Each Testing 
 | Scenario | Version | What it checks |
 | --- | --- | --- |
 | <a id="scenario-response-code-400"></a>**`response-code-400`** – 400 Bad Request | 2.0.0 · Required | A malformed query MUST return HTTP 400. |
-| <a id="scenario-response-code-404"></a>**`response-code-404`** – 404 Not Found | 2.0.0 · Required | A malformed query MUST return HTTP 404. |
+| <a id="scenario-response-code-404"></a>**`response-code-404`** – 404 Not Found | 2.0.0 · Required | A request for a resource that does not exist MUST return HTTP 404. |
 
 ### Lookup Resource (2.1.0)
 


### PR DESCRIPTION
The §6 Scenario Catalog row for `response-code-404` read "A malformed query MUST return HTTP 404." A 404 is a *not-found* — that scenario requests a nonexistent resource (`/ResourceNotFound`); the malformed-query case is the 400 row.

This corrects the one row to match the fixed generator in reso-tools #274, keeping the catalog in lockstep. Caught by #274's adversarial review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
