### PR TITLE
fix(site): stop heading anchors from smushing text and clipping the icon

### DIFF
--- a/.github/pages/_layouts/default.html
+++ b/.github/pages/_layouts/default.html
@@ -623,15 +623,18 @@
       scroll-margin-top: 5rem;
     }
     .content .heading-anchor {
-      display: inline-flex;
-      align-items: center;
+      /* inline (not flex) so whitespace text nodes between the heading words and
+         inline `code` are preserved; a flex wrapper drops them and smushes the text */
+      display: inline;
       color: inherit;
       text-decoration: none;
       position: relative;
     }
     .content .heading-anchor .anchor-icon {
       position: absolute;
-      left: -1.5rem;
+      /* to the right of the heading text so it is never clipped in the left gutter */
+      left: 100%;
+      margin-left: 0.375rem;
       top: 50%;
       transform: translateY(-50%);
       display: inline-flex;


### PR DESCRIPTION
## What

Two rendering bugs on transport.reso.org proposal pages (surfaced on web-api-core), both in the heading-anchor styling in `.github/pages/_layouts/default.html`. The spec markdown itself is correct — verified all 64 code-span headings are properly spaced in source, and the emitted HTML has correct spaces and anchor ids.

### 1. Heading text smushing
Headings with inline `code` rendered smushed — "2.5.4 `$select` Operator" showed as **2.5.4$selectOperator**. The layout JS wraps each heading's children in an `<a class="heading-anchor">`, and that wrapper was `display: inline-flex`. A flex container drops whitespace-only text nodes, so the spaces between "2.5.4", the `<code>`, and "Operator" disappeared. Changed the wrapper to `display: inline`, which preserves them (an `<a>` is inline by default; nothing else relied on the flex).

### 2. Anchor icon clipped on the left
The hover link icon was `position: absolute; left: -1.5rem`, placing it in the left gutter where it was clipped. Moved it to the right of the heading text (`left: 100%` + a 0.375rem gap).

## Note
CSS-only. I can't render Jekyll locally, so this wants a visual check on the deployed site (or a preview build) — both headings and the hover icon, including dark mode and any wrapped (long) headings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
